### PR TITLE
Updated test to show message is not actually sent (it's sitting on transport.queue)

### DIFF
--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -29,6 +29,7 @@ vows.describe('winston-syslog').addBatch({
    "the log() method": helpers.testSyslogLevels(transport, "should log messages to syslogd", function (ign, err, ok) {
      assert.isTrue(!err);
      assert.isTrue(ok);
+     assert.equal(transport.queue.length, 0); //This is > 0 because winston-syslog.js line 124
    })
  }
 }).export(module);


### PR DESCRIPTION
I was having problems implementing winston-syslog (problems = ['https://gist.github.com/1782990' ,'https://gist.github.com/1783187']). This update to the test shows the message hasn't been sent but it's actually sitting on the queue of the transport. I'd be happy to look into this next week.
