### PR TITLE
Fix unnecessary JSONification of 'message' if meta not supplied.

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -108,7 +108,7 @@ Syslog.prototype.name = 'Syslog';
 //
 Syslog.prototype.log = function (level, msg, meta, callback) {
   var self = this,
-      data = meta ? winston.clone(meta) : {}, 
+      data = Object.keys(meta).length ? winston.clone(meta) : {}, 
       syslogMsg,
       buffer;
       
@@ -122,7 +122,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     host:     this.localhost,
     app_id:   this.app_id || process.title,
     date:     new Date(),
-    message:  meta ? JSON.stringify(data) : msg
+    message:  Object.keys(meta).length ? JSON.stringify(data) : msg
   });
 
   //


### PR DESCRIPTION
The test of `meta ? ... : ...` seems insufficient to test whether `meta` was actually passed into the logging function with meaningful data. Since `meta` appears to always be passed (but as an empty object `{}` if it was not specified), this test was always true.

This patch tests for an empty object slightly more effectively than `meta ? ... : ...` which allows the ternary operation to succeed or fail based on the intent of the code.

Without patch:

```
logger.info('Hello!');
logger.info('Hello!', {with: 'metadata this time'});

Oct 23 11:14:08 my_hostname localhost minion.js[10702]: {"message":"Hello!"}
Oct 23 11:14:08 my_hostname localhost minion.js[10702]: {"with":"metadata this time","message":"Hello!"}
```

With patch:

```
logger.info('Hello!');
logger.info('Hello!', {with: 'metadata this time'});

Oct 23 11:12:38 my_hostname localhost minion.js[10699]: Hello!
Oct 23 11:12:38 my_hostname localhost minion.js[10699]: {"with":"metadata this time","message":"Hello!"}
```
