### PR TITLE
connect callback needs arg to signal message queue

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -107,10 +107,8 @@ Syslog.prototype.name = 'Syslog';
 // metadata, `meta`, to the specified `level`.
 //
 Syslog.prototype.log = function (level, msg, meta, callback) {
-  var self = this,
-      data = typeof(meta) == 'object' && meta && Object.keys(meta).length ? winston.clone(meta) : {},
-      syslogMsg,
-      buffer;
+  var data = typeof(meta) == 'object' && meta && Object.keys(meta).length ? winston.clone(meta) : {},
+      syslogMsg;
 
   if (!~levels.indexOf(level)) {
     return callback(new Error('Cannot log unknown syslog level: ' + level));
@@ -124,6 +122,14 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     date:     new Date(),
     message:  typeof(meta) == 'object' && meta && Object.keys(meta).length ? JSON.stringify(data) : msg
   });
+
+  this.rawlog(syslogMsg, callback);
+}
+
+// Allow very tight control on all fields in logged message.
+Syslog.prototype.rawlog = function(syslogMsg, callback) {
+  var self = this,
+      buffer;
 
   //
   // Attempt to connect to the socket


### PR DESCRIPTION
I hit the following error on a mac running node 0.10.29:

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: This socket is closed.
    at Socket._write (net.js:637:19)
    at doWrite (_stream_writable.js:226:10)
    at writeOrBuffer (_stream_writable.js:216:5)
    at Socket.Writable.write (_stream_writable.js:183:11)
    at Socket.write (net.js:615:40)
    at /Users/alfred/jut/product/node_modules/winston-syslog/lib/winston-syslog.js:162:19
    at Syslog.connect (/Users/alfred/jut/product/node_modules/winston-syslog/lib/winston-syslog.js:238:3)
    at Syslog.log (/Users/alfred/jut/product/node_modules/winston-syslog/lib/winston-syslog.js:131:8)
    at emit (/Users/alfred/jut/product/node_modules/winston/lib/winston/logger.js:179:17)
    at /Users/alfred/jut/product/node_modules/async/lib/async.js:111:13

It looks like the callback inside Syslog.prototype.connect should be called with an arg to signal to Syslog.prototype.log that it should queue its message.
