### PR TITLE
Convert winston levels to syslog levels

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -24,6 +24,10 @@ var levels = Object.keys({
   emerg: 7
 });
 
+var winstonLevels2SyslogLevels = {
+  warn: 'warning'
+};
+
 //
 // ### function Syslog (options)
 // #### @options {Object} Options for this instance.
@@ -111,6 +115,12 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
       data = typeof(meta) == 'object' && meta && Object.keys(meta).length ? winston.clone(meta) : {},
       syslogMsg,
       buffer;
+
+  // Convert winston levels to syslog levels 
+  // to be more compatible
+  if (winstonLevels2SyslogLevels.hasOwnProperty(level)) {
+    level = winstonLevels2SyslogLevels[level];
+  }
 
   if (!~levels.indexOf(level)) {
     return callback(new Error('Cannot log unknown syslog level: ' + level));


### PR DESCRIPTION
Instead of forcing people to install new levels and change the code, the transport itself should do as much as possible to do the automatic conversion and be compatible with winston's transport interface. I can't image the world where transport for logging system would dictate the top-level changes. Look at `logging` for python or `log4j` for Java for instance.
