### PR TITLE
Use net module instead of unix-dgram for unix protocol

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -10,8 +10,7 @@ var dgram = require('dgram'),
     net = require('net'),
     util = require('util'),
     glossy = require('glossy'),
-    winston = require('winston'),
-    unix = require('unix-dgram');
+    winston = require('winston');
 
 var levels = Object.keys({
   debug: 0,
@@ -25,12 +24,33 @@ var levels = Object.keys({
 });
 
 //
+// ### function callCallback (callback[, args...])
+// Helper function to call a callback function using
+// process.nextTick to maintain the asynchronous nature
+// of the code as well as properly handle the cases when
+// callback function is not provided which means we should
+// not call it at all.
+//
+function callCallback() {
+  var args = Array.prototype.slice.call(arguments, 0);
+  var callback = args.shift();
+
+  if (!callback) {
+    return;
+  }
+
+  process.nextTick(function onNextTick() {
+    callback.apply(this, args);
+  });
+}
+
+//
 // ### function Syslog (options)
 // #### @options {Object} Options for this instance.
 // Constructor function for the Syslog Transport capable of sending
 // RFC 3164 and RFC 5424 compliant messages.
 //
-var Syslog = exports.Syslog = function (options) {
+var Syslog = exports.Syslog = function Syslog(options) {
   winston.Transport.call(this, options);
   options = options || {};
   // Set transport name
@@ -51,14 +71,14 @@ var Syslog = exports.Syslog = function (options) {
   this.path     = options.path     || null;
   this.app_id   = options.app_id   || null;
   this.protocol = options.protocol || 'udp4';
-  this.isDgram  = /^udp|unix/.test(this.protocol);
+  this.isDgram  = /^udp/.test(this.protocol);
 
   if (!/^udp|unix|tcp/.test(this.protocol)) {
     throw new Error('Invalid syslog protocol: ' + this.protocol);
   }
 
   if (/^unix/.test(this.protocol) && !this.path) {
-    throw new Error('`options.path` is required on unix dgram sockets.');
+    throw new Error('`options.path` is required on unix sockets.');
   }
 
   //
@@ -106,14 +126,14 @@ Syslog.prototype.name = 'Syslog';
 // Core logging method exposed to Winston. Logs the `msg` and optional
 // metadata, `meta`, to the specified `level`.
 //
-Syslog.prototype.log = function (level, msg, meta, callback) {
+Syslog.prototype.log = function log(level, msg, meta, callback) {
   var self = this,
       data = typeof(meta) == 'object' && meta && Object.keys(meta).length ? winston.clone(meta) : {},
       syslogMsg,
       buffer;
 
   if (!~levels.indexOf(level)) {
-    return callback(new Error('Cannot log unknown syslog level: ' + level));
+    return callCallback(callback, new Error('Cannot log unknown syslog level: ' + level));
   }
 
   data.message = msg;
@@ -128,7 +148,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
   //
   // Attempt to connect to the socket
   //
-  this.connect(function (err) {
+  this.connect(function onConnect(err) {
     if (err) {
       //
       // If there was an error enqueue the message
@@ -139,8 +159,8 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     //
     // On any error writing to the socket, enqueue the message
     //
-    function onError (logErr) {
-      if (logErr) { self.queue.push(syslogMsg) }
+    function onError(logErr) {
+      if (logErr) { self.queue.push(syslogMsg); }
       self.emit('logged');
       self.inFlight--;
     }
@@ -150,46 +170,44 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     //
     if (self.isDgram) {
       buffer = new Buffer(syslogMsg);
-      if (self.protocol.match(/^udp/)) {
-        self.inFlight++;
-        self.socket.send(buffer, 0, buffer.length, self.port, self.host, onError);
-      }
-      else {
-        self.socket.send(buffer, 0, buffer.length, self.path, onError);
-      }
+      self.socket.send(buffer, 0, buffer.length, self.port, self.host, onError);
     }
     else {
       self.socket.write(syslogMsg, 'utf8', onError);
     }
+
+    self.inFlight++;
   });
 
-  callback(null, true);
+  callCallback(callback, null, true);
 };
+
 //
 // ### function close ()
 // Closes the socket used by this transport freeing the resource.
 //
-Syslog.prototype.close = function () {
+Syslog.prototype.close = function close() {
   var self = this,
       max = 6,
       attempt = 0;
   (function _close(){
-    if(attempt>=max || (self.queue.length === 0 && self.inFlight <= 0)){
+    if (attempt >= max || (self.queue.length === 0 && self.inFlight <= 0)) {
         self.socket.close();
         self.emit('closed', self.socket);
-    }else{
+    } else {
       attempt++
       setTimeout(_close, 200 * attempt);
     }
   }());
-}
+};
+
 //
 // ### function connect (callback)
 // #### @callback {function} Continuation to respond to when complete.
 // Connects to the remote syslog server using `dgram` or `net` depending
 // on the `protocol` for this instance.
 //
-Syslog.prototype.connect = function (callback) {
+Syslog.prototype.connect = function connect(callback) {
   var self = this, readyEvent;
 
   //
@@ -197,52 +215,52 @@ Syslog.prototype.connect = function (callback) {
   //
   if (this.socket) {
     return (!this.socket.readyState) || (this.socket.readyState === 'open')
-      ? callback(null)
-      : callback(true);
+      ? callCallback(callback, null)
+      : callCallback(callback, true);
   }
 
   //
-  // Create the appropriate socket type.
+  // For UDP protocol we use dgram.Socket
   //
   if (this.isDgram) {
-    if (self.protocol.match(/^udp/)) {
-      this.socket = new dgram.Socket(this.protocol);
-    }
-    else {
-      this.socket = new unix.createSocket('unix_dgram');
-    }
+    this.socket = new dgram.Socket(this.protocol);
 
-    return callback(null);
+    callCallback(callback);
+
+    return;
   }
-  else {
-    this.socket = new net.Socket({ type: this.protocol });
-    this.socket.setKeepAlive(true);
-    this.socket.setNoDelay();
-    readyEvent = 'connect';
-  }
+
+  //
+  // For TCP and UNIX protocols we can use net.Socket
+  //
+  this.socket = new net.Socket({ type: this.protocol });
+  this.socket.setKeepAlive(true);
+  this.socket.setNoDelay();
+  readyEvent = 'connect';
 
   //
   // On any error writing to the socket, emit the `logged` event
   // and the `error` event.
   //
-  function onError (logErr) {
-    if (logErr) { self.emit('error', logErr) }
+  function onError(logErr) {
+    if (logErr) { self.emit('error', logErr); }
     self.emit('logged');
     self.inFlight--;
   }
 
-  //
-  // Indicate to the callee that the socket is not ready. This
-  // will enqueue the current message for later.
-  //
-  callback();
-
+  function reConnect() {
+    if (self.protocol === 'unix') {
+      self.socket.connect(self.path);
+    } else {
+      self.socket.connect(self.port, self.host);
+    }
+  }
 
   //
   // Listen to the appropriate events on the socket that
   // was just created.
   //
-  this.socket.on(readyEvent, function () {
+  this.socket.on(readyEvent, function onReadyEvent() {
     //
     // When the socket is ready, write the current queue
     // to it.
@@ -253,15 +271,15 @@ Syslog.prototype.connect = function (callback) {
     self.queue = [];
     self.retries = 0;
     self.connected = true;
-  }).on('error', function (ex) {
+  }).on('error', function onError(ex) {
     //
     // TODO: Pass this error back up
     //
-  }).on('end', function (ex) {
+  }).on('end', function onEnd(ex) {
     //
     // Nothing needs to be done here.
     //
-  }).on('close', function (ex) {
+  }).on('close', function onClose(ex) {
     //
     // Attempt to reconnect on lost connection(s), progressively
     // increasing the amount of time between each try.
@@ -269,15 +287,21 @@ Syslog.prototype.connect = function (callback) {
     var interval = Math.pow(2, self.retries);
     self.connected = false;
 
-    setTimeout(function () {
+    setTimeout(function onSetTimeout() {
       self.retries++;
-      self.socket.connect(self.port, self.host);
+      reConnect();
     }, interval * 1000);
-  }).on('timeout', function () {
+  }).on('timeout', function onTimeout() {
     if (self.socket.readyState !== 'open') {
       self.socket.destroy();
     }
   });
 
-  this.socket.connect(this.port, this.host);
+  reConnect();
+
+  //
+  // Indicate to the callee that the socket is not ready. This
+  // will enqueue the current message for later.
+  //
+  callCallback(callback, true);
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "syslog"],
   "dependencies": {
-    "glossy": "0.x.x",
-    "unix-dgram": ">= 0.0.1"
+    "glossy": "0.x.x"
   },
   "devDependencies": {
     "winston": "0.5.x",


### PR DESCRIPTION
- core `net` module does support unix sockets so there is no need for
  `unix-dgram` which also requires the compilation of binding and we are
  better to keep it as pure JS solution
- give a name to anonymous functions to improve stack traces
- improve callbacks handling by calling them using `process.nextTick`
  instead of doing it right away which breaks asynchronous nature of
  the code
- increase `inFlight` counter for all protocols as it is being decreased
  for all protocols as well
- add missing semicolons
- add whitespaces around operators for consistency
