### PR TITLE
Make "unix-dgram" optional dependancy, otherwise module fails to install...

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -10,8 +10,7 @@ var dgram = require('dgram'),
     net = require('net'),
     util = require('util'),
     glossy = require('glossy'),
-    winston = require('winston'),
-    unix = require('unix-dgram');
+    winston = require('winston');
 
 var levels = Object.keys({
   debug: 0,
@@ -209,7 +208,7 @@ Syslog.prototype.connect = function (callback) {
       this.socket = new dgram.Socket(this.protocol);
     }
     else {
-      this.socket = new unix.createSocket('unix_dgram');
+      this.socket = new require('unix-dgram').createSocket('unix_dgram');
     }
 
     return callback(null);

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "syslog"],
   "dependencies": {
-    "glossy": "0.x.x",
-    "unix-dgram": ">= 0.0.1"
+    "glossy": "0.x.x"
   },
+  "optionalDependencies": {
+    "unix-dgram": ">= 0.0.1"
+  },  
   "devDependencies": {
     "winston": "0.5.x",
     "vows": "0.6.x"


### PR DESCRIPTION
... on solaris (joyent cloud). I believe it is quite safe patch but it allows to use winston-syslog module on system where unix-drgam wan't install (as I mention solaris alike in joyent cloud). 
