### PR TITLE
connect callback needs arg to signal message queue

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -235,7 +235,7 @@ Syslog.prototype.connect = function (callback) {
   // Indicate to the callee that the socket is not ready. This
   // will enqueue the current message for later.
   //
-  callback();
+  callback(true);
 
 
   //


### PR DESCRIPTION
(this is a re-submit of #20 , with just the single intended commit).

I hit the following error on a mac running node 0.10.29:

events.js:72
throw er; // Unhandled 'error' event
^
Error: This socket is closed.
at Socket._write (net.js:637:19)
at doWrite (_stream_writable.js:226:10)
at writeOrBuffer (_stream_writable.js:216:5)
at Socket.Writable.write (_stream_writable.js:183:11)
at Socket.write (net.js:615:40)
at /Users/alfred/jut/product/node_modules/winston-syslog/lib/winston-syslog.js:162:19
at Syslog.connect (/Users/alfred/jut/product/node_modules/winston-syslog/lib/winston-syslog.js:238:3)
at Syslog.log (/Users/alfred/jut/product/node_modules/winston-syslog/lib/winston-syslog.js:131:8)
at emit (/Users/alfred/jut/product/node_modules/winston/lib/winston/logger.js:179:17)
at /Users/alfred/jut/product/node_modules/async/lib/async.js:111:13

It looks like the callback inside Syslog.prototype.connect should be called with an arg to signal to Syslog.prototype.log that it should queue its message.
