### PR TITLE
Make "unix-dgram" optional dependancy, add queue limit and fix TCP protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 * __localhost:__ Host to indicate that log messages are coming from (Default: `localhost`).
 * __type:__ The type of the syslog protocol to use (Default: `BSD`).
 * __app_name:__ The name of the application (Default: `process.title`).
+* __queue_max:__ Maximum amount of messages queued without established connection (Default: `100`)
 
 *Metadata:* Logged as string compiled by [glossy][3].
 

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -50,6 +50,7 @@ var Syslog = exports.Syslog = function (options) {
   this.path     = options.path     || null;
   this.app_id   = options.app_id   || null;
   this.protocol = options.protocol || 'udp4';
+  this.queue_max = options.queue_max || 100;
   this.isDgram  = /^udp|unix/.test(this.protocol);
 
   if (!/^udp|unix|tcp/.test(this.protocol)) {
@@ -132,6 +133,8 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
       //
       // If there was an error enqueue the message
       //
+      if (self.queue.length>self.queue_max)
+        self.queue.shift();
       return self.queue.push(syslogMsg);
     }
 
@@ -139,7 +142,11 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     // On any error writing to the socket, enqueue the message
     //
     function onError (logErr) {
-      if (logErr) { self.queue.push(syslogMsg) }
+      if (logErr) {
+        if (self.queue.length>self.queue_max)
+          self.queue.shift();
+        self.queue.push(syslogMsg)
+      }
       self.emit('logged');
       self.inFlight--;
     }
@@ -154,11 +161,12 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
         self.socket.send(buffer, 0, buffer.length, self.port, self.host, onError);
       }
       else {
+        self.inFlight++;
         self.socket.send(buffer, 0, buffer.length, self.path, onError);
       }
     }
     else {
-      self.socket.write(syslogMsg, 'utf8', onError);
+      self.socket.write(syslogMsg+"\n", 'utf8', onError);
     }
   });
 
@@ -246,7 +254,8 @@ Syslog.prototype.connect = function (callback) {
     // When the socket is ready, write the current queue
     // to it.
     //
-    self.socket.write(self.queue.join(''), 'utf8', onError);
+    self.inFlight++;
+    self.socket.write(self.queue.join('\n')+'\n', 'utf8', onError);
 
     self.emit('logged');
     self.queue = [];
@@ -264,8 +273,9 @@ Syslog.prototype.connect = function (callback) {
     //
     // Attempt to reconnect on lost connection(s), progressively
     // increasing the amount of time between each try.
+    // Lets set 10 min max (its quite safe);
     //
-    var interval = Math.pow(2, self.retries);
+    var interval = Math.min(Math.pow(2, self.retries),600)
     self.connected = false;
 
     setTimeout(function () {

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -10,8 +10,7 @@ var dgram = require('dgram'),
     net = require('net'),
     util = require('util'),
     glossy = require('glossy'),
-    winston = require('winston'),
-    unix = require('unix-dgram');
+    winston = require('winston');
 
 var levels = Object.keys({
   debug: 0,
@@ -209,7 +208,7 @@ Syslog.prototype.connect = function (callback) {
       this.socket = new dgram.Socket(this.protocol);
     }
     else {
-      this.socket = new unix.createSocket('unix_dgram');
+      this.socket = new require('unix-dgram').createSocket('unix_dgram');
     }
 
     return callback(null);

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "syslog"],
   "dependencies": {
-    "glossy": "0.x.x",
-    "unix-dgram": ">= 0.0.1"
+    "glossy": "0.x.x"
   },
+  "optionalDependencies": {
+    "unix-dgram": ">= 0.0.1"
+  },  
   "devDependencies": {
     "winston": "0.5.x",
     "vows": "0.6.x"


### PR DESCRIPTION
Hi there. Earlier I already submitted unix-dgram fix. Somebody answered that you will do something better in #22, but finally it became something different and issues is exist. Optional dependency is absolutely safe thing. System that will have it will work, other (solaris) will not fail.
Next to that we was need to use TCP protocol and it appears to be not working. There is no message delimiters (LF). Additionally to avoid memory overuse we add limit for message queue. Hop you find it useful.
