### PR TITLE
Send Syslog.prototype.log arguments through common log function

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -12,7 +12,8 @@ var dgram = require('dgram'),
     cycle = require('cycle'),
     glossy = require('glossy'),
     winston = require('winston'),
-    unix = require('unix-dgram');
+    unix = require('unix-dgram'),
+    common = require('winston/lib/winston/common');
 
 var levels = Object.keys({
   debug: 0,
@@ -44,6 +45,15 @@ var Syslog = exports.Syslog = function (options) {
   this.retries = 0;
   this.queue = [];
   this.inFlight = 0;
+
+  this.json        = options.json        || false;
+  this.colorize    = options.colorize    || false;
+  this.prettyPrint = options.prettyPrint || false;
+  this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
+  this.label       = options.label       || null;
+  this.logstash    = options.logstash    || false;
+  this.depth       = options.depth       || null;
 
   //
   // Merge the options for the target Syslog server.
@@ -110,7 +120,6 @@ Syslog.prototype.name = 'Syslog';
 //
 Syslog.prototype.log = function (level, msg, meta, callback) {
   var self = this,
-      data = typeof meta === 'object' && meta && Object.keys(meta).length ? winston.clone(cycle.decycle(meta)) : {},
       syslogMsg,
       buffer;
 
@@ -118,13 +127,30 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     return callback(new Error('Cannot log unknown syslog level: ' + level));
   }
 
-  data.message = msg;
+  var output = common.log({
+    colorize:    this.colorize,
+    json:        this.json,
+    level:       level,
+    message:     msg,
+    meta:        meta,
+    stringify:   this.stringify,
+    timestamp:   this.timestamp,
+    showLevel:   this.showLevel,
+    prettyPrint: this.prettyPrint,
+    raw:         this.raw,
+    label:       this.label,
+    logstash:    this.logstash,
+    depth:       this.depth,
+    formatter:   this.formatter,
+    humanReadableUnhandledException: this.humanReadableUnhandledException
+  });
+
   syslogMsg = this.producer.produce({
     severity: level,
     host:     this.localhost,
     app_id:   this.appId || process.title,
     date:     new Date(),
-    message:  typeof meta === 'object' && meta && Object.keys(meta).length ? JSON.stringify(data) : msg
+    message:  output
   });
 
   //


### PR DESCRIPTION
Send Syslog.prototype.log level, msg, data, and other options through common log function.

This allows for a bunch of additional formatting options to be supported when logging to Syslog. For example, now we can prettyPrint JSON no problem.