### PR TITLE
we should be passing this.appName to glossy instead of this.app_name

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -78,7 +78,7 @@ var Syslog = exports.Syslog = function (options) {
   this.socket   = null;
   this.producer = new glossy.Produce({
     type:     this.type,
-    appName:  this.app_name,
+    appName:  this.appName,
     pid:      this.pid,
     facility: this.facility
   });


### PR DESCRIPTION
Looks like a bug in the initialization of `glossy` `appName`. Tests pass... Thanks, L