### PR TITLE
Updated winston-syslog version to use most recent syslog minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "stylezero": "~2.1.1",
     "vows": "0.8.x",
-    "winston": "0.8.x"
+    "winston": "^0.9.0"
   },
   "main": "./lib/winston-syslog",
   "scripts": {


### PR DESCRIPTION
I updated the package so that winston-syslog will use the most recent version of Winston that is < 1.0.

I can't think of a good reason to keep it at 0.8.x. For my specific case, I am upgrading this because prior to 0.9.0, Winston could not properly handle logging errors.