### PR TITLE
Use node-unix-dgram v0.2.1 for iosj-v2.0.0 compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "cycle": "~1.0.3",
     "glossy": "0.x.x",
-    "unix-dgram": "~0.1.1"
+    "unix-dgram": "~0.2.1"
   },
   "devDependencies": {
     "stylezero": "~2.1.1",


### PR DESCRIPTION
This allows the project to be used with iojs-v2.0.0 and above.