### PR TITLE
Honor silent option, don't include timestamp in msg

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -54,6 +54,7 @@ var Syslog = exports.Syslog = function (options) {
   this.label       = options.label       || null;
   this.logstash    = options.logstash    || false;
   this.depth       = options.depth       || null;
+  this.silent      = options.silent      || false;
 
   //
   // Merge the options for the target Syslog server.
@@ -118,14 +119,18 @@ Syslog.prototype.name = 'Syslog';
 // Core logging method exposed to Winston. Logs the `msg` and optional
 // metadata, `meta`, to the specified `level`.
 //
-Syslog.prototype.log = function (level, msg, meta, callback) {
-  var self = this,
-      syslogMsg,
-      buffer;
+Syslog.prototype.log = function (timestamp, level, msg, meta, callback) {
+  if (this.silent) {
+    return callback(null, true);
+  }
 
   if (!~levels.indexOf(level)) {
     return callback(new Error('Cannot log unknown syslog level: ' + level));
   }
+
+  var self = this,
+      syslogMsg,
+      buffer;
 
   var output = common.log({
     colorize:    this.colorize,
@@ -134,7 +139,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     message:     msg,
     meta:        meta,
     stringify:   this.stringify,
-    timestamp:   this.timestamp,
+    timestamp:   null,
     showLevel:   this.showLevel,
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
@@ -149,7 +154,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     severity: level,
     host:     this.localhost,
     app_id:   this.appId || process.title,
-    date:     new Date(),
+    date:     timestamp || this.timestamp || new Date(),
     message:  output
   });
 


### PR DESCRIPTION
Optionally include timestamp as part of each call to log.

Please note that the optional passing of timestamp is dependent on https://github.com/winstonjs/winston/pull/634.