### PR TITLE
Add support for configurable end-of-line character to be added per me…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 * __localhost:__ Host to indicate that log messages are coming from (Default: `localhost`).
 * __type:__ The type of the syslog protocol to use (Default: `BSD`).
 * __app_name:__ The name of the application (Default: `process.title`).
+* __eol:__ The end of line character to be added to the end of the message (Default: Message without modifications).
 
 *Metadata:* Logged as string compiled by [glossy][3].
 

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -64,6 +64,7 @@ var Syslog = exports.Syslog = function (options) {
   this.appId    = options.appId    || options.app_id || null;
   this.protocol = options.protocol || 'udp4';
   this.isDgram  = /^udp|^unix/.test(this.protocol);
+  this.endOfLine = options.eol;
 
   if (!/^udp|unix|unix-connect|tcp/.test(this.protocol)) {
     throw new Error('Invalid syslog protocol: ' + this.protocol);
@@ -150,7 +151,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     host:     this.localhost,
     app_id:   this.appId || process.title,
     date:     new Date(),
-    message:  output
+    message:  this.endOfLine ? output + this.endOfLine : output
   });
 
   //


### PR DESCRIPTION
Fixes issue: 
https://github.com/winstonjs/winston-syslog/issues/47 TCP messages are being written to a single line in syslog