### PR TITLE
fixed close method if called before socket was created

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -226,7 +226,7 @@ Syslog.prototype.close = function () {
 
   (function _close() {
     if (attempt >= max || (self.queue.length === 0 && self.inFlight <= 0)) {
-      self.socket.close();
+      self.socket && self.socket.close();
       self.emit('closed', self.socket);
     }
     else {


### PR DESCRIPTION
If close method is called before socket was created (before any log method was called)
the socket is null and calling socket.close() causes an error.

this fixes this issue