### PR TITLE
fix for winston.config.syslog.levels which are not in the right priority order for winston

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -13,18 +13,19 @@ var dgram = require('dgram'),
     glossy = require('glossy'),
     winston = require('winston'),
     unix = require('unix-dgram'),
-    common = require('winston/lib/winston/common');
+    common = require('winston/lib/winston/common'),
+    syslogLevels = {
+      debug: 0,
+      info: 1,
+      notice: 2,
+      warning: 3,
+      error: 4,
+      crit: 5,
+      alert: 6,
+      emerg: 7
+    };
 
-var levels = Object.keys({
-  debug: 0,
-  info: 1,
-  notice: 2,
-  warning: 3,
-  error: 4,
-  crit: 5,
-  alert: 6,
-  emerg: 7
-});
+var levels = Object.keys(syslogLevels);
 
 //
 // ### function Syslog (options)
@@ -105,6 +106,7 @@ util.inherits(Syslog, winston.Transport);
 // is available and thus backwards compatible.
 //
 winston.transports.Syslog = Syslog;
+winston.config.syslog.levels = syslogLevels;
 
 //
 // Expose the name of this Transport on the prototype


### PR DESCRIPTION
`winston` default logging priority order is ascending goes from lowest 0 (silly) to highest 5 (error)
but syslog priority order is descending from lowest 7 (debug) to highest 0 (emerg)

this means that when setting a log level for `winston` when using syslog
you will actually log below that level instead of above it
so setting logger.level='info' (which is the default)
will actually log debug and info but will not log notice warning and so on.

I'm not sure if this is the right place for this fix
but I opend an [issue](https://github.com/winstonjs/winston/issues/722) for `winston` a few days ago and didn't get any attention
since the bad config mostly affects `winston-syslog` users I thought it can be fixed within 
`winston-syslog` a better fix might be to have the levels conf under Syslog namespace and not requiring winston config at all but that will require changing the docs