### PR TITLE
Always emit closed event after removing transport

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -226,7 +226,7 @@ Syslog.prototype.close = function () {
 
   (function _close() {
     if (attempt >= max || (self.queue.length === 0 && self.inFlight <= 0)) {
-      self.socket.close();
+      self.socket && self.socket.close();
       self.emit('closed', self.socket);
     }
     else {

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -226,7 +226,10 @@ Syslog.prototype.close = function () {
 
   (function _close() {
     if (attempt >= max || (self.queue.length === 0 && self.inFlight <= 0)) {
-      self.socket && self.socket.close();
+      if (self.socket) {
+        self.socket.close();
+      }
+
       self.emit('closed', self.socket);
     }
     else {

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -23,7 +23,7 @@ function closeTopic() {
   var transport = new winston.transports.Syslog(),
       logger = new winston.Logger({ transports: [transport] });
 
-  logger.log('debug', 'Test message to actually use socket');
+  logger.log('info', 'Test message to actually use socket');
   logger.remove({ name: 'syslog' });
 
   return transport;
@@ -41,20 +41,17 @@ vows.describe('winston-syslog').addBatch({
       assert.isTrue(!err);
       assert.isTrue(ok);
       assert.equal(transport.queue.length, 0); // This is > 0 because winston-syslog.js line 124
-    })
-    //
-    // TODO: Figure out why this hangs.
-    //
-    // 'on close': {
-    //   topic: closeTopic,
-    //   on: {
-    //     closed: {
-    //       'closes the socket': function (socket) {
-    //         assert.isNull(socket._handle);
-    //       }
-    //     }
-    //   }
-    // }
+    }),
+    'on close': {
+      topic: closeTopic,
+      on: {
+        closed: {
+          'closes the socket': function (socket) {
+            assert.isNull(socket._handle);
+          }
+        }
+      }
+    }
   }
 }).export(module);
 


### PR DESCRIPTION
This wasn't working when the transport hadn't been used.
Update tests.