### PR TITLE
[api] allow false and null for localhost option

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -76,7 +76,7 @@ var Syslog = exports.Syslog = function (options) {
   //
   // Merge the default message options.
   //
-  this.localhost = options.localhost || 'localhost';
+  this.localhost = typeof options.localhost !== 'undefined' ? options.localhost : 'localhost';
   this.type      = options.type      || 'BSD';
   this.facility  = options.facility  || 'local0';
   this.pid       = options.pid       || process.pid;

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -1,0 +1,73 @@
+var fs = require('fs');
+var vows = require('vows');
+var assert = require('assert');
+var winston = require('winston');
+var dgram = require('dgram');
+var parser = require('glossy').Parse;
+var Syslog = require('../lib/winston-syslog').Syslog;
+
+var PORT = 11229;
+var server;
+var transport;
+
+vows.describe('syslog messages').addBatch({
+  'opening fake syslog server': {
+    topic: function () {
+      var self = this;
+      server = dgram.createSocket('udp4');
+      server.on('listening', function () {
+        self.callback();
+      });
+
+      server.bind(PORT);
+    },
+    'default format': {
+      topic: function () {
+        var self = this;
+        server.once('message', function (msg) {
+          parser.parse(msg, function (d) {
+            self.callback(undefined, d);
+          });
+        });
+
+        transport = new winston.transports.Syslog({
+          port: PORT
+        });
+
+        transport.log('debug', 'ping', null, function (err) {
+          assert.ifError(err);
+        });
+      },
+      'should have host field set to localhost': function (msg) {
+        assert.equal(msg.host, 'localhost');
+        transport.close();
+      },
+      'setting locahost option to a different falsy value (null)': {
+        topic: function () {
+          var self = this;
+          server.once('message', function (msg) {
+            parser.parse(msg, function (d) {
+              self.callback(undefined, d);
+            });
+          });
+
+          transport = new winston.transports.Syslog({
+            port: PORT,
+            localhost: null
+          });
+
+          transport.log('debug', 'ping2', null, function (err) {
+            assert.ifError(err);
+          });
+        },
+        'should have host different from localhost': function (msg) {
+          assert.notEqual(msg.host, 'localhost');
+          transport.close();
+        }
+      }
+    },
+    teardown: function () {
+      server.close();
+    }
+  }
+}).export(module);

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -71,6 +71,21 @@ vows.describe('winston-syslog').addBatch({
           }
         }
       }
+    },
+    'localhost option': {
+      'should default to localhost': function () {
+        var transport = new winston.transports.Syslog();
+        assert.equal(transport.localhost, 'localhost');
+        transport.close();
+      },
+      'should accept other falsy entries as valid': function () {
+        var transport = new winston.transports.Syslog({ localhost: null });
+        assert.isNull(transport.localhost);
+        transport.close();
+        transport = new winston.transports.Syslog({ localhost: false });
+        assert.equal(transport.localhost, false);
+        transport.close();
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
So that the host field in the Syslog message can be left empty.