### PR TITLE
Update unix-gram dependency to ~0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "cycle": "~1.0.3",
     "glossy": "0.x.x",
-    "unix-dgram": "~0.2.1"
+    "unix-dgram": "~0.2.2"
   },
   "devDependencies": {
     "stylezero": "~2.1.1",


### PR DESCRIPTION
New version of unix-dgram has support for Node 4 and 5