### PR TITLE
Make sure to only try to call close on a socket if it exists

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -223,7 +223,7 @@ Syslog.prototype.close = function () {
 
   (function _close() {
     if (attempt >= max || (self.queue.length === 0 && self.inFlight <= 0)) {
-      if (self.socket) {
+      if (self.socket && typeof self.socket.close === 'function') {
         self.socket.close();
       }
 


### PR DESCRIPTION
When trying to close this transport I would occasionally get `self.socket.close is not a function` with a stack of:

```
TypeError: self.socket.close is not a function
    at _close [as _onTimeout] ([path]/node_modules/winston-syslog/lib/winston-syslog.js:227:21)
    at Timer.listOnTimeout (timers.js:92:15)
```

This PR is to address that.
