### PR TITLE
fix broken titles in syslog

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -146,7 +146,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
   syslogMsg = this.producer.produce({
     severity: level,
     host:     this.localhost,
-    appName:   this.appId || process.title,
+    appName:   this.appName || process.title,
     date:     new Date(),
     message:  this.endOfLine ? output + this.endOfLine : output
   });


### PR DESCRIPTION
Since updating from winston-syslog 1.2.1 to 1.2.3, I noticed that my syslog messages no longer include the name set as `app_name`, instantiating winston syslog transport. Instead, I can read `node /path/to/my/app.js`.

Are we sure we want to transmit appId to glossy? Shouldn't this be appName instead?

Also, it seems I've hereby dropped the last reference to appId. What's that variable for, actually? Shouldn't we drop it completely?