### PR TITLE
FIX: Set protocol family for TCP sockets

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,26 @@
+'use strict';
+
+exports.parseProtocol = function parseProtocol(protocol) {
+  switch (protocol) {
+    case 'unix':
+    case 'unix-connect':
+      return { type: 'unix', family: null, isDgram: true };
+
+    case 'udp':
+    case 'udp4':
+      return { type: 'udp', family: 4, isDgram: true };
+
+    case 'udp6':
+      return { type: 'udp', family: 6, isDgram: true };
+
+    case 'tcp':
+    case 'tcp4':
+      return { type: 'tcp', family: 4 };
+
+    case 'tcp6':
+      return { type: 'tcp', family: 6 };
+
+    default:
+      throw new Error('Invalid syslog protocol: ' + protocol);
+  }
+};

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -10,6 +10,7 @@ var dgram = require('dgram'),
     net = require('net'),
     util = require('util'),
     cycle = require('cycle'),
+    utils = require('./utils'),
     glossy = require('glossy'),
     winston = require('winston'),
     common = require('winston/lib/winston/common');
@@ -59,14 +60,15 @@ var Syslog = exports.Syslog = function (options) {
   this.port     = options.port     || 514;
   this.path     = options.path     || null;
   this.protocol = options.protocol || 'udp4';
-  this.isDgram  = /^udp|^unix/.test(this.protocol);
-  this.endOfLine = options.eol;
 
-  if (!/^udp|unix|unix-connect|tcp/.test(this.protocol)) {
-    throw new Error('Invalid syslog protocol: ' + this.protocol);
-  }
+  var parsedProtocol = utils.parseProtocol(this.protocol);
 
-  if (/^unix/.test(this.protocol) && !this.path) {
+  this.protocolType   = parsedProtocol.type;
+  this.protocolFamily = parsedProtocol.family;
+  this.isDgram        = parsedProtocol.isDgram;
+  this.endOfLine      = options.eol;
+
+  if (this.protocolType === 'unix' && !this.path) {
     throw new Error('`options.path` is required on unix dgram sockets.');
   }
 
@@ -181,7 +183,7 @@ Syslog.prototype.log = function (level, msg, meta, callback) {
     if (self.isDgram) {
       buffer = new Buffer(syslogMsg);
 
-      if (self.protocol.match(/^udp/)) {
+      if (self.protocolType === 'udp') {
         self.inFlight++;
         self.socket.send(buffer, 0, buffer.length, self.port, self.host, onError);
       }
@@ -256,20 +258,21 @@ Syslog.prototype.connect = function (callback) {
   // Create the appropriate socket type.
   //
   if (this.isDgram) {
-    if (self.protocol.match(/^udp/)) {
-      this.socket = new dgram.Socket(this.protocol);
+    if (this.protocol === 'unix-connect') {
+      return this._unixDgramConnect(callback);
     }
-    else if (self.protocol === 'unix') {
+    else if (this.protocol === 'unix') {
       this.socket = require('unix-dgram').createSocket('unix_dgram');
     }
     else {
-      return this._unixDgramConnect(callback);
+      // UDP protocol
+      this.socket = new dgram.Socket(this.protocol);
     }
 
     return callback(null);
   }
   else {
-    this.socket = new net.Socket({ type: this.protocol });
+    this.socket = new net.Socket();
     this.socket.setKeepAlive(true);
     this.socket.setNoDelay();
     readyEvent = 'connect';
@@ -332,7 +335,16 @@ Syslog.prototype.connect = function (callback) {
     }
   });
 
-  this.socket.connect(this.port, this.host);
+  var connectConfig = {
+    host: this.host,
+    port: this.port
+  };
+
+  if (this.protocolFamily) {
+    connectConfig.family = this.protocolFamily;
+  }
+
+  this.socket.connect(connectConfig);
 };
 
 Syslog.prototype._unixDgramConnect = function (cb) {


### PR DESCRIPTION
Previously, the library was setting the TCP socket protocol family via `new net.Socket({ type: this.protocol })`. This is valid for UDP datagram sockets but TCP sockets expect the family to be passed as an integer on the `family` property.