### PR TITLE
Custom Producer setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 *Metadata:* Logged as string compiled by [glossy][3].
 
 By default, syslog messages are produced by [glossy][3], but you can override that behavior by providing a
-custom **Producer** instance via **customProducer** setting.
+custom **Producer** instance via the **customProducer** setting.
 
 ## Log Levels
 Because syslog only allows a subset of the levels available in [winston][0], levels that do not match will be ignored. Therefore, in order to use `winston-syslog` effectively, you should indicate to [winston][0] that you want to use the syslog levels:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 
 *Metadata:* Logged as string compiled by [glossy][3].
 
+By default, syslog messages are produced by [glossy][3], but you can override that behavior by providing
+custom **Producer** instance via **customProducer** setting.
+
 ## Log Levels
 Because syslog only allows a subset of the levels available in [winston][0], levels that do not match will be ignored. Therefore, in order to use `winston-syslog` effectively, you should indicate to [winston][0] that you want to use the syslog levels:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 
 *Metadata:* Logged as string compiled by [glossy][3].
 
-By default, syslog messages are produced by [glossy][3], but you can override that behavior by providing
+By default, syslog messages are produced by [glossy][3], but you can override that behavior by providing a
 custom **Producer** instance via **customProducer** setting.
 
 ## Log Levels

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -85,7 +85,8 @@ var Syslog = exports.Syslog = function (options) {
   // Setup our Syslog and network members for later use.
   //
   this.socket   = null;
-  this.producer = new glossy.Produce({
+  var Producer = options.customProducer || glossy.Produce;
+  this.producer = new Producer({
     type:     this.type,
     appName:  this.appName,
     pid:      this.pid,


### PR DESCRIPTION
This PR is addressed to this issue - https://github.com/winstonjs/winston-syslog/issues/81.
Adds an additional setting `customProvider` for an ability to implement custom syslog format.