### PR TITLE
Refactor for winston 3.x

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "populist",
+  "rules": {
+    "one-var": ["error", { var: "never", let: "never", const: "never" }],
+    "strict": 0
+  }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Syslog transport for [winston][0].
 ### Installing winston-syslog
 
 ``` bash
-  $ npm install winston 
+  $ npm install winston
   $ npm install winston-syslog
 ```
 
@@ -26,15 +26,15 @@ The [winston][0] codebase has been growing significantly with contributions and 
 To use the Syslog transport in [winston][0], you simply need to require it and then either add it to an existing [winston][0] logger or pass an instance to a new [winston][0] logger:
 
 ``` js
-  var winston = require('winston');
-  
+  const winston = require('winston');
+
   //
-  // Requiring `winston-syslog` will expose 
+  // Requiring `winston-syslog` will expose
   // `winston.transports.Syslog`
   //
   require('winston-syslog').Syslog;
-  
-  winston.add(winston.transports.Syslog, options);
+
+  winston.add(new winston.transports.Syslog(options));
 ```
 
 In addition to the options accepted by the syslog (compliant with [RFC 3164][1] and [RFC 5424][2]), the Riak transport also accepts the following options. It is worth noting that the riak-js debug option is set to *false* by default:
@@ -56,8 +56,13 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 Because syslog only allows a subset of the levels available in [winston][0], levels that do not match will be ignored. Therefore, in order to use `winston-syslog` effectively, you should indicate to [winston][0] that you want to use the syslog levels:
 
 ``` js
-  var winston = require('winston');
-  winston.setLevels(winston.config.syslog.levels);
+  const winston = require('winston');
+  const logger = winston.createLogger({
+    levels: winston.config.syslog.levels,
+    transports: [
+      new winston.transports.Syslog()
+    ]
+  })
 ```
 
 The `Syslog` transport will only log to the level that are available in the syslog protocol. These are (in increasing order of severity):

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Because syslog only allows a subset of the levels available in [winston][0], lev
     transports: [
       new winston.transports.Syslog()
     ]
-  })
+  });
 ```
 
 The `Syslog` transport will only log to the level that are available in the syslog protocol. These are (in increasing order of severity):

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -158,12 +158,14 @@ class Syslog extends Transport {
           this.inFlight++;
           this.socket.send(buffer, 0, buffer.length, this.port, this.host, onError);
         } else if (this.protocol === 'unix') {
+          this.inFlight++;
           this.socket.send(buffer, 0, buffer.length, this.path, onError);
         } else if (this.congested) {
           this.queue.push(syslogMsg);
         } else {
           this.socket.once('congestion', onCongestion);
           this.socket.once('error', onError);
+          this.inFlight++;
           this.socket.send(buffer, () => {
             this.socket.removeListener('congestion', onCongestion);
             this.socket.removeListener('error', onError);

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -14,7 +14,7 @@ const winston = require('winston');
 const Transport = require('winston-transport');
 const { MESSAGE, LEVEL } = require('triple-beam');
 
-var levels = Object.keys({
+const levels = Object.keys({
   debug: 0,
   info: 1,
   notice: 2,

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -6,13 +6,10 @@
  *
  */
 
-var dgram = require('dgram'),
-    net = require('net'),
-    util = require('util'),
-    cycle = require('cycle'),
-    utils = require('./utils'),
-    glossy = require('glossy'),
-    common = require('winston/lib/winston/common');
+const dgram = require('dgram');
+const net = require('net');
+const utils = require('./utils');
+const glossy = require('glossy');
 const winston = require('winston');
 const Transport = require('winston-transport');
 const { MESSAGE, LEVEL } = require('triple-beam');
@@ -34,71 +31,340 @@ var levels = Object.keys({
 // Constructor function for the Syslog Transport capable of sending
 // RFC 3164 and RFC 5424 compliant messages.
 //
-var Syslog = exports.Syslog = function (options) {
-  Transport.call(this, options);
-  options = options || {};
+class Syslog extends Transport {
   //
-  // Setup connection state
+  // Expose the name of this Transport on the prototype
   //
-  this.connected = false;
-  this.congested = false;
-  this.retries = 0;
-  this.queue = [];
-  this.inFlight = 0;
+  get name() {
+    return 'syslog';
+  }
 
-  this.json        = options.json        || false;
-  this.colorize    = options.colorize    || false;
-  this.prettyPrint = options.prettyPrint || false;
-  this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
-  this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
-  this.label       = options.label       || null;
-  this.logstash    = options.logstash    || false;
-  this.depth       = options.depth       || null;
+  constructor(options = {}) {
+    //
+    // Inherit from `winston-transport`.
+    //
+    super(options);
 
-  //
-  // Merge the options for the target Syslog server.
-  //
-  this.host     = options.host     || 'localhost';
-  this.port     = options.port     || 514;
-  this.path     = options.path     || null;
-  this.protocol = options.protocol || 'udp4';
+    //
+    // Setup connection state
+    //
+    this.connected = false;
+    this.congested = false;
+    this.retries = 0;
+    this.queue = [];
+    this.inFlight = 0;
 
-  var parsedProtocol = utils.parseProtocol(this.protocol);
+    //
+    // Merge the options for the target Syslog server.
+    //
+    this.setOptions(options);
 
-  this.protocolType   = parsedProtocol.type;
-  this.protocolFamily = parsedProtocol.family;
-  this.isDgram        = parsedProtocol.isDgram;
-  this.endOfLine      = options.eol;
+    //
+    // Setup our Syslog and network members for later use.
+    //
+    this.socket   = null;
+    this.producer = new glossy.Produce({
+      type: this.type,
+      appName: this.appName,
+      pid: this.pid,
+      facility: this.facility
+    });
+  }
 
-  if (this.protocolType === 'unix' && !this.path) {
-    throw new Error('`options.path` is required on unix dgram sockets.');
+  setOptions(options) {
+    this.host = options.host || 'localhost';
+    this.port = options.port || 514;
+    this.path = options.path || null;
+    this.protocol = options.protocol || 'udp4';
+    this.endOfLine = options.eol;
+
+    this.parseProtocol(this.protocol);
+
+    //
+    // Merge the default message options.
+    //
+    this.localhost = typeof options.localhost !== 'undefined' ? options.localhost : 'localhost';
+    this.type = options.type || 'BSD';
+    this.facility = options.facility || 'local0';
+    this.pid = options.pid || process.pid;
+    this.appName = options.appName || options.app_name || process.title;
+  }
+
+  parseProtocol(protocol = this.protocol) {
+    const parsedProtocol = utils.parseProtocol(protocol);
+
+    this.protocolType   = parsedProtocol.type;
+    this.protocolFamily = parsedProtocol.family;
+    this.isDgram        = parsedProtocol.isDgram;
+
+    if (this.protocolType === 'unix' && !this.path) {
+      throw new Error('`options.path` is required on unix dgram sockets.');
+    }
   }
 
   //
-  // Merge the default message options.
+  // ### function log (info, callback)
+  // #### @info {object} All relevant log information
+  // #### @callback {function} Continuation to respond to when complete.
+  // Core logging method exposed to Winston. Logs the `msg` and optional
+  // metadata, `meta`, to the specified `level`.
   //
-  this.localhost = typeof options.localhost !== 'undefined' ? options.localhost : 'localhost';
-  this.type      = options.type      || 'BSD';
-  this.facility  = options.facility  || 'local0';
-  this.pid       = options.pid       || process.pid;
-  this.appName   = options.appName   || options.app_name  || process.title;
+  log(info, callback) {
+    if (!~levels.indexOf(info[LEVEL])) {
+      return callback(new Error('Cannot log unknown syslog level: ' + info[LEVEL]));
+    }
+
+    const output = info[MESSAGE];
+
+    const syslogMsg = this.producer.produce({
+      severity: info[LEVEL],
+      host: this.localhost,
+      date: new Date(),
+      message: this.endOfLine ? output + this.endOfLine : output
+    });
+
+    //
+    // Attempt to connect to the socket
+    //
+    this.connect((err) => {
+      if (err) {
+        //
+        // If there was an error enqueue the message
+        //
+        this.queue.push(syslogMsg);
+
+        return callback(err);
+      }
+
+      //
+      // On any error writing to the socket, enqueue the message
+      //
+      const onError = (logErr) => {
+        if (logErr) {
+          this.queue.push(syslogMsg);
+        }
+        this.emit('logged');
+        this.inFlight--;
+      };
+
+      const onCongestion = () => {
+        onError(new Error('Congestion Error'));
+      };
+
+      const sendDgram = () => {
+        const buffer = new Buffer(syslogMsg);
+
+        if (this.protocolType === 'udp') {
+          this.inFlight++;
+          this.socket.send(buffer, 0, buffer.length, this.port, this.host, onError);
+        } else if (this.protocol === 'unix') {
+          this.socket.send(buffer, 0, buffer.length, this.path, onError);
+        } else if (this.congested) {
+          this.queue.push(syslogMsg);
+        } else {
+          this.socket.once('congestion', onCongestion);
+          this.socket.once('error', onError);
+          this.socket.send(buffer, () => {
+            this.socket.removeListener('congestion', onCongestion);
+            this.socket.removeListener('error', onError);
+            onError();
+          });
+        }
+      };
+
+      //
+      // Write to the `tcp*`, `udp*`, or `unix` socket.
+      //
+      if (this.isDgram) {
+        sendDgram();
+      } else {
+        this.socket.write(syslogMsg, 'utf8', onError);
+      }
+
+      callback(null, true);
+    });
+  }
 
   //
-  // Setup our Syslog and network members for later use.
+  // ### function close ()
+  // Closes the socket used by this transport freeing the resource.
   //
-  this.socket   = null;
-  this.producer = new glossy.Produce({
-    type:     this.type,
-    appName:  this.appName,
-    pid:      this.pid,
-    facility: this.facility
-  });
-};
+  close() {
+    const max = 6;
+    let attempt = 0;
 
-//
-// Inherit from `winston-transport`.
-//
-util.inherits(Syslog, Transport);
+    const _close = () => {
+      if (attempt >= max || (this.queue.length === 0 && this.inFlight <= 0)) {
+        if (this.socket) {
+          this.socket.close();
+        }
+
+        this.emit('closed', this.socket);
+      } else {
+        attempt++;
+        setTimeout(_close, 200 * attempt);
+      }
+    };
+    _close();
+  }
+
+  connectDgram(callback) {
+    if (this.protocol === 'unix-connect') {
+      return this._unixDgramConnect(callback);
+    } else if (this.protocol === 'unix') {
+      this.socket = require('unix-dgram').createSocket('unix_dgram');
+    } else {
+      // UDP protocol
+      this.socket = new dgram.Socket(this.protocol);
+    }
+
+    return callback(null);
+  }
+  //
+  // ### function connect (callback)
+  // #### @callback {function} Continuation to respond to when complete.
+  // Connects to the remote syslog server using `dgram` or `net` depending
+  // on the `protocol` for this instance.
+  //
+  connect(callback) {
+    //
+    // If the socket already exists then respond
+    //
+    if (this.socket) {
+      return (!this.socket.readyState) || (this.socket.readyState === 'open')
+        ? callback(null)
+        : callback(true);
+    }
+
+    //
+    // Create the appropriate socket type.
+    //
+    if (this.isDgram) {
+      return this.connectDgram(callback);
+    }
+
+    this.socket = new net.Socket();
+    this.socket.setKeepAlive(true);
+    this.socket.setNoDelay();
+
+    this.setupEvents();
+
+    const connectConfig = {
+      host: this.host,
+      port: this.port
+    };
+
+    if (this.protocolFamily) {
+      connectConfig.family = this.protocolFamily;
+    }
+
+    this.socket.connect(connectConfig);
+
+    //
+    // Indicate to the callee that the socket is not ready. This
+    // will enqueue the current message for later.
+    //
+    callback(true);
+  }
+
+  setupEvents() {
+    const readyEvent = 'connect';
+    //
+    // On any error writing to the socket, emit the `logged` event
+    // and the `error` event.
+    //
+    const onError = (logErr) => {
+      if (logErr) { this.emit('error', logErr); }
+      this.emit('logged');
+      this.inFlight--;
+    };
+
+    //
+    // Listen to the appropriate events on the socket that
+    // was just created.
+    //
+    this.socket.on(readyEvent, () => {
+      //
+      // When the socket is ready, write the current queue
+      // to it.
+      //
+      this.socket.write(this.queue.join(''), 'utf8', onError);
+
+      this.emit('logged');
+      this.queue = [];
+      this.retries = 0;
+      this.connected = true;
+    }).on('error', function () {
+      //
+      // TODO: Pass this error back up
+      //
+    }).on('close', () => {
+      //
+      // Attempt to reconnect on lost connection(s), progressively
+      // increasing the amount of time between each try.
+      //
+      const interval = Math.pow(2, this.retries);
+      this.connected = false;
+
+      setTimeout(() => {
+        this.retries++;
+        this.socket.connect(this.port, this.host);
+      }, interval * 1000);
+    }).on('timeout', () => {
+      if (this.socket.readyState !== 'open') {
+        this.socket.destroy();
+      }
+    });
+  }
+
+  _unixDgramConnect(callback) {
+    const flushQueue = () => {
+      let sentMsgs = 0;
+      this.queue.forEach((msg) => {
+        const buffer = new Buffer(msg);
+
+        if (!this.congested) {
+          this.socket.send(buffer, function () {
+            ++sentMsgs;
+          });
+        }
+      });
+
+      this.queue.splice(0, sentMsgs);
+    };
+
+    this.socket = require('unix-dgram').createSocket('unix_dgram');
+    this.socket.on('error', (err) => {
+      this.emit('error', err);
+
+      if (err.syscall === 'connect') {
+        this.socket.close();
+        this.socket = null;
+        return callback(err);
+      }
+      if (err.syscall === 'send') {
+        this.socket.close();
+        this.socket = null;
+      }
+    });
+
+    this.socket.on('connect', () => {
+      this.on('congestion', () => {
+        this.congested = true;
+      });
+
+      this.on('writable', () => {
+        this.congested = false;
+        flushQueue();
+      });
+
+      flushQueue();
+      callback();
+    });
+
+    this.socket.connect(this.path);
+  }
+}
 
 //
 // Define a getter so that `winston.transports.Syslog`
@@ -106,279 +372,6 @@ util.inherits(Syslog, Transport);
 //
 winston.transports.Syslog = Syslog;
 
-//
-// Expose the name of this Transport on the prototype
-//
-Syslog.prototype.name = 'syslog';
-//
-// ### function log (level, msg, [meta], callback)
-// #### @level {string} Target level to log to
-// #### @msg {string} Message to log
-// #### @meta {Object} **Optional** Additional metadata to log.
-// #### @callback {function} Continuation to respond to when complete.
-// Core logging method exposed to Winston. Logs the `msg` and optional
-// metadata, `meta`, to the specified `level`.
-//
-Syslog.prototype.log = function (info, callback) {
-  var self = this,
-      syslogMsg,
-      buffer;
-
-  if (!~levels.indexOf(info[LEVEL])) {
-    return callback(new Error('Cannot log unknown syslog level: ' + info[LEVEL]));
-  }
-
-  var output = info[MESSAGE];
-
-  syslogMsg = this.producer.produce({
-    severity: info[LEVEL],
-    host:     this.localhost,
-    date:     new Date(),
-    message:  this.endOfLine ? output + this.endOfLine : output
-  });
-
-  //
-  // Attempt to connect to the socket
-  //
-  this.connect(function (err) {
-    if (err) {
-      //
-      // If there was an error enqueue the message
-      //
-      self.queue.push(syslogMsg);
-
-      return callback(err);
-    }
-
-    //
-    // On any error writing to the socket, enqueue the message
-    //
-    function onError(logErr) {
-      if (logErr) { self.queue.push(syslogMsg) }
-      self.emit('logged');
-      self.inFlight--;
-    }
-
-    function onCongestion() {
-      onError(new Error('Congestion Error'));
-    }
-
-    //
-    // Write to the `tcp*`, `udp*`, or `unix` socket.
-    //
-    if (self.isDgram) {
-      buffer = new Buffer(syslogMsg);
-
-      if (self.protocolType === 'udp') {
-        self.inFlight++;
-        self.socket.send(buffer, 0, buffer.length, self.port, self.host, onError);
-      }
-      else if (self.protocol === 'unix') {
-        self.socket.send(buffer, 0, buffer.length, self.path, onError);
-      }
-      else {
-        if (self.congested) {
-          self.queue.push(syslogMsg);
-        }
-        else {
-          self.socket.once('congestion', onCongestion);
-          self.socket.once('error', onError);
-          self.socket.send(buffer, function () {
-            self.socket.removeListener('congestion', onCongestion);
-            self.socket.removeListener('error', onError);
-            onError();
-          });
-        }
-      }
-    }
-    else {
-      self.socket.write(syslogMsg, 'utf8', onError);
-    }
-
-    callback(null, true);
-  });
-};
-//
-// ### function close ()
-// Closes the socket used by this transport freeing the resource.
-//
-Syslog.prototype.close = function () {
-  var self = this,
-      max = 6,
-      attempt = 0;
-
-  (function _close() {
-    if (attempt >= max || (self.queue.length === 0 && self.inFlight <= 0)) {
-      if (self.socket) {
-        self.socket.close();
-      }
-
-      self.emit('closed', self.socket);
-    }
-    else {
-      attempt++;
-      setTimeout(_close, 200 * attempt);
-    }
-  }());
-};
-
-//
-// ### function connect (callback)
-// #### @callback {function} Continuation to respond to when complete.
-// Connects to the remote syslog server using `dgram` or `net` depending
-// on the `protocol` for this instance.
-//
-Syslog.prototype.connect = function (callback) {
-  var self = this, readyEvent;
-
-  //
-  // If the socket already exists then respond
-  //
-  if (this.socket) {
-    return (!this.socket.readyState) || (this.socket.readyState === 'open')
-      ? callback(null)
-      : callback(true);
-  }
-
-  //
-  // Create the appropriate socket type.
-  //
-  if (this.isDgram) {
-    if (this.protocol === 'unix-connect') {
-      return this._unixDgramConnect(callback);
-    }
-    else if (this.protocol === 'unix') {
-      this.socket = require('unix-dgram').createSocket('unix_dgram');
-    }
-    else {
-      // UDP protocol
-      this.socket = new dgram.Socket(this.protocol);
-    }
-
-    return callback(null);
-  }
-  else {
-    this.socket = new net.Socket();
-    this.socket.setKeepAlive(true);
-    this.socket.setNoDelay();
-    readyEvent = 'connect';
-  }
-
-  //
-  // On any error writing to the socket, emit the `logged` event
-  // and the `error` event.
-  //
-  function onError(logErr) {
-    if (logErr) { self.emit('error', logErr) }
-    self.emit('logged');
-    self.inFlight--;
-  }
-
-  //
-  // Indicate to the callee that the socket is not ready. This
-  // will enqueue the current message for later.
-  //
-  callback(true);
-
-  //
-  // Listen to the appropriate events on the socket that
-  // was just created.
-  //
-  this.socket.on(readyEvent, function () {
-    //
-    // When the socket is ready, write the current queue
-    // to it.
-    //
-    self.socket.write(self.queue.join(''), 'utf8', onError);
-
-    self.emit('logged');
-    self.queue = [];
-    self.retries = 0;
-    self.connected = true;
-  }).on('error', function (ex) {
-    //
-    // TODO: Pass this error back up
-    //
-  }).on('end', function (ex) {
-    //
-    // Nothing needs to be done here.
-    //
-  }).on('close', function (ex) {
-    //
-    // Attempt to reconnect on lost connection(s), progressively
-    // increasing the amount of time between each try.
-    //
-    var interval = Math.pow(2, self.retries);
-    self.connected = false;
-
-    setTimeout(function () {
-      self.retries++;
-      self.socket.connect(self.port, self.host);
-    }, interval * 1000);
-  }).on('timeout', function () {
-    if (self.socket.readyState !== 'open') {
-      self.socket.destroy();
-    }
-  });
-
-  var connectConfig = {
-    host: this.host,
-    port: this.port
-  };
-
-  if (this.protocolFamily) {
-    connectConfig.family = this.protocolFamily;
-  }
-
-  this.socket.connect(connectConfig);
-};
-
-Syslog.prototype._unixDgramConnect = function (cb) {
-  var self = this;
-
-  function flushQueue() {
-    var sentMsgs = 0;
-    self.queue.forEach(function (msg) {
-      var buffer = new Buffer(msg);
-
-      if (!self.congested) {
-        self.socket.send(buffer, function () {
-          ++sentMsgs;
-        });
-      }
-    });
-
-    self.queue.splice(0, sentMsgs);
-  }
-
-  this.socket = require('unix-dgram').createSocket('unix_dgram');
-  this.socket.on('error', function (err) {
-    if (err.syscall === 'connect') {
-      self.socket.close();
-      self.socket = null;
-      cb(err);
-    }
-    if (err.syscall === 'send') {
-      self.socket.close();
-      self.socket = null;
-    }
-
-    self.emit('error', err);
-  });
-
-  this.socket.on('connect', function () {
-    this.on('congestion', function () {
-      self.congested = true;
-    });
-
-    this.on('writable', function () {
-      self.congested = false;
-      flushQueue();
-    });
-
-    flushQueue();
-    cb();
-  });
-
-  this.socket.connect(this.path);
+module.exports = {
+  Syslog
 };

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -12,8 +12,10 @@ var dgram = require('dgram'),
     cycle = require('cycle'),
     utils = require('./utils'),
     glossy = require('glossy'),
-    winston = require('winston'),
     common = require('winston/lib/winston/common');
+const winston = require('winston');
+const Transport = require('winston-transport');
+const { MESSAGE, LEVEL } = require('triple-beam');
 
 var levels = Object.keys({
   debug: 0,
@@ -33,7 +35,7 @@ var levels = Object.keys({
 // RFC 3164 and RFC 5424 compliant messages.
 //
 var Syslog = exports.Syslog = function (options) {
-  winston.Transport.call(this, options);
+  Transport.call(this, options);
   options = options || {};
   //
   // Setup connection state
@@ -94,9 +96,9 @@ var Syslog = exports.Syslog = function (options) {
 };
 
 //
-// Inherit from `winston.Transport`.
+// Inherit from `winston-transport`.
 //
-util.inherits(Syslog, winston.Transport);
+util.inherits(Syslog, Transport);
 
 //
 // Define a getter so that `winston.transports.Syslog`
@@ -117,35 +119,19 @@ Syslog.prototype.name = 'syslog';
 // Core logging method exposed to Winston. Logs the `msg` and optional
 // metadata, `meta`, to the specified `level`.
 //
-Syslog.prototype.log = function (level, msg, meta, callback) {
+Syslog.prototype.log = function (info, callback) {
   var self = this,
       syslogMsg,
       buffer;
 
-  if (!~levels.indexOf(level)) {
-    return callback(new Error('Cannot log unknown syslog level: ' + level));
+  if (!~levels.indexOf(info[LEVEL])) {
+    return callback(new Error('Cannot log unknown syslog level: ' + info[LEVEL]));
   }
 
-  var output = common.log({
-    colorize:    this.colorize,
-    json:        this.json,
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    stringify:   this.stringify,
-    timestamp:   this.timestamp,
-    showLevel:   this.showLevel,
-    prettyPrint: this.prettyPrint,
-    raw:         this.raw,
-    label:       this.label,
-    logstash:    this.logstash,
-    depth:       this.depth,
-    formatter:   this.formatter,
-    humanReadableUnhandledException: this.humanReadableUnhandledException
-  });
+  var output = info[MESSAGE];
 
   syslogMsg = this.producer.produce({
-    severity: level,
+    severity: info[LEVEL],
     host:     this.localhost,
     date:     new Date(),
     message:  this.endOfLine ? output + this.endOfLine : output

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -143,7 +143,7 @@ class Syslog extends Transport {
         if (logErr) {
           this.queue.push(syslogMsg);
         }
-        this.emit('logged');
+        this.emit('logged', info);
         this.inFlight--;
       };
 

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -318,6 +318,8 @@ class Syslog extends Transport {
   }
 
   _unixDgramConnect(callback) {
+    const self = this;
+
     const flushQueue = () => {
       let sentMsgs = 0;
       this.queue.forEach((msg) => {
@@ -348,13 +350,13 @@ class Syslog extends Transport {
       }
     });
 
-    this.socket.on('connect', () => {
+    this.socket.on('connect', function () {
       this.on('congestion', () => {
-        this.congested = true;
+        self.congested = true;
       });
 
       this.on('writable', () => {
-        this.congested = false;
+        self.congested = false;
         flushQueue();
       });
 

--- a/package.json
+++ b/package.json
@@ -26,15 +26,14 @@
   },
   "optionalDependencies": {
     "unix-dgram": "~0.2.1"
-  },  
+  },
   "devDependencies": {
     "stylezero": "^2.3.0",
     "vows": "~0.8.1",
-    "winston": "^2.1.0"
+    "winston": "^3.0.0-rc0"
   },
   "main": "./lib/winston-syslog",
   "scripts": {
-    "pretest": "stylezero lib/ test/",
     "test": "vows test/*-test.js --spec"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "winston-syslog",
   "description": "A syslog transport for winston",
-  "version": "1.2.6",
+  "version": "2.0.0",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "contributors": [
     {
       "name": "Squeeks",
       "email": "privacymyass@gmail.com"
+    },
+    {
+      "name": "Mempf",
+      "email": "mempf.com@gmail.com"
     }
   ],
   "repository": {
@@ -28,16 +32,18 @@
     "unix-dgram": "~0.2.1"
   },
   "devDependencies": {
-    "stylezero": "^2.3.0",
+    "eslint-config-populist": "^4.1.0",
     "vows": "~0.8.1",
     "winston": "^3.0.0-rc0"
   },
   "main": "./lib/winston-syslog",
   "scripts": {
+    "lint": "populist lib/*.js",
+    "pretest": "npm run lint",
     "test": "vows test/*-test.js --spec"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.2.2"
   },
   "license": "MIT"
 }

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var fs = require('fs');
 var vows = require('vows');
 var assert = require('assert');
@@ -9,6 +11,8 @@ var Syslog = require('../lib/winston-syslog').Syslog;
 var PORT = 11229;
 var server;
 var transport;
+
+const { MESSAGE, LEVEL } = require('triple-beam');
 
 vows.describe('syslog messages').addBatch({
   'opening fake syslog server': {
@@ -33,8 +37,7 @@ vows.describe('syslog messages').addBatch({
         transport = new winston.transports.Syslog({
           port: PORT
         });
-
-        transport.log('debug', 'ping', null, function (err) {
+        transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping' }, function (err) {
           assert.ifError(err);
         });
       },
@@ -56,7 +59,7 @@ vows.describe('syslog messages').addBatch({
             localhost: null
           });
 
-          transport.log('debug', 'ping2', null, function (err) {
+          transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping2' }, function (err) {
             assert.ifError(err);
           });
         },
@@ -79,7 +82,7 @@ vows.describe('syslog messages').addBatch({
               appName: 'hello'
             });
 
-            transport.log('debug', 'app name test', null, function (err) {
+            transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'app name test' }, function (err) {
               assert.ifError(err);
             });
           },
@@ -102,7 +105,7 @@ vows.describe('syslog messages').addBatch({
                 app_name: 'hello'
               });
 
-              transport.log('debug', 'app name test', null, function (err) {
+              transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'app name test' }, function (err) {
                 assert.ifError(err);
               });
             },

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -21,7 +21,7 @@ function assertSyslog(transport) {
 
 function closeTopicInfo() {
   var transport = new winston.transports.Syslog(),
-      logger = new winston.Logger({ transports: [transport] });
+      logger = new winston.createLogger({ transports: [transport] });
 
   logger.log('info', 'Test message to actually use socket');
   logger.remove(transport);
@@ -31,7 +31,7 @@ function closeTopicInfo() {
 
 function closeTopicDebug() {
   var transport = new winston.transports.Syslog(),
-      logger = new winston.Logger({ transports: [transport] });
+      logger = new winston.createLogger({ transports: [transport] });
 
   logger.log('debug', 'Test message to actually use socket');
   logger.remove(transport);
@@ -46,12 +46,6 @@ vows.describe('winston-syslog').addBatch({
     'should have the proper methods defined': function () {
       assertSyslog(transport);
     },
-    'the log() method': helpers.testSyslogLevels(transport, 'should log messages to syslogd', function (ign, err, ok) {
-      assert.isNull(ign);
-      assert.isTrue(!err);
-      assert.isTrue(ok);
-      assert.equal(transport.queue.length, 0); // This is > 0 because winston-syslog.js line 124
-    }),
     teardown: function () {
       transport.close();
     },
@@ -92,10 +86,10 @@ vows.describe('winston-syslog').addBatch({
     },
     'adding / removing transport to syslog': {
       'should just work': function () {
-        winston.add(winston.transports.Syslog);
-        winston.remove(winston.transports.Syslog);
-        winston.add(winston.transports.Syslog);
-        winston.remove(winston.transports.Syslog);
+        winston.add(new winston.transports.Syslog());
+        winston.remove(new winston.transports.Syslog());
+        winston.add(new winston.transports.Syslog());
+        winston.remove(new winston.transports.Syslog());
       }
     }
   }

--- a/test/unix-connect-test.js
+++ b/test/unix-connect-test.js
@@ -6,6 +6,8 @@ var unix = require('unix-dgram');
 var parser = require('glossy').Parse;
 var Syslog = require('../lib/winston-syslog').Syslog;
 
+const { MESSAGE, LEVEL } = require('triple-beam');
+
 var SOCKNAME = '/tmp/unix_dgram.sock';
 
 var transport = new Syslog({
@@ -31,7 +33,7 @@ vows.describe('unix-connect').addBatch({
         self.callback(null, err);
       });
 
-      transport.log('debug', 'data' + (++times), null, function (err) {
+      transport.log({ [LEVEL]: 'debug', [MESSAGE]: `data${++times}` }, function (err) {
         assert(err);
         assert.equal(err.syscall, 'connect');
         assert.equal(transport.queue.length, 1);
@@ -51,7 +53,8 @@ vows.describe('unix-connect').addBatch({
         parser.parse(buf, function (d) {
           ++n;
           assert(n <= 2);
-          assert.equal(d.message, 'node[' + process.pid + ']: debug: data' + n);
+          assert.equal(d.message, 'node[' + process.pid + ']: data' + n);
+          assert.equal(d.severity, 'debug');
           if (n === 2) {
             self.callback();
           }
@@ -59,7 +62,7 @@ vows.describe('unix-connect').addBatch({
       });
 
       server.bind(SOCKNAME);
-      transport.log('debug', 'data' + (++times), null, function (err) {
+      transport.log({ [LEVEL]: 'debug', [MESSAGE]: `data${++times}` }, function (err) {
         assert.ifError(err);
       });
     },
@@ -77,7 +80,7 @@ vows.describe('unix-connect').addBatch({
 
       server.close();
 
-      transport.log('debug', 'data' + (++times), null, function (err) {
+     transport.log({ [LEVEL]: 'debug', [MESSAGE]: `data${++times}` }, function (err) {
         assert.ifError(err);
         assert.equal(transport.queue.length, 1);
       });
@@ -103,7 +106,8 @@ vows.describe('unix-connect').addBatch({
         parser.parse(buf, function (d) {
           ++n;
           assert(n <= 4);
-          assert.equal(d.message, 'node[' + process.pid + ']: debug: data' + n);
+          assert.equal(d.message, 'node[' + process.pid + ']: data' + n);
+          assert.equal(d.severity, 'debug');
           if (n === 4) {
             self.callback();
           }
@@ -111,7 +115,7 @@ vows.describe('unix-connect').addBatch({
       });
 
       server.bind(SOCKNAME);
-      transport.log('debug', 'data' + (++times), null, function (err) {
+      transport.log({ [LEVEL]: 'debug', [MESSAGE]: `data${++times}` }, function (err) {
         assert.ifError(err);
       });
     },


### PR DESCRIPTION
Rewrite of the winston-syslog module for use with winston >= 3.0.0.

-Added eslint using same rules as winston 3.0.0.
-Updated tests to work with winston 3.0.0.
-Updated README.
-Increased version to 2.0.0 (will no longer with with winston 2.x)