### PR TITLE
Ensure winston version is >= 3.0.0; Add note in README.md too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Syslog transport for [winston][0].
 
+## Requirements
+
+* winston >= 3.0.0
+
 ## Installation
 
 ### Installing npm (node package manager)
@@ -20,7 +24,7 @@ A Syslog transport for [winston][0].
 ## Motivation
 `tldr;?`: To break the [winston][0] codebase into small modules that work together.
 
-The [winston][0] codebase has been growing significantly with contributions and other logging transports. This is **awesome**. However, taking a ton of additional dependencies just to do something simple like logging to the Console and a File is overkill.  
+The [winston][0] codebase has been growing significantly with contributions and other logging transports. This is **awesome**. However, taking a ton of additional dependencies just to do something simple like logging to the Console and a File is overkill.
 
 ## Usage
 To use the Syslog transport in [winston][0], you simply need to require it and then either add it to an existing [winston][0] logger or pass an instance to a new [winston][0] logger:

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -14,6 +14,11 @@ const winston = require('winston');
 const Transport = require('winston-transport');
 const { MESSAGE, LEVEL } = require('triple-beam');
 
+// Ensure we have the correct winston here.
+if (Number(winston.version.split('.')[0]) < 3) {
+  throw new Error('Winston-syslog requires winston >= 3.0.0');
+}
+
 const levels = Object.keys({
   debug: 0,
   info: 1,


### PR DESCRIPTION
This bit me when I was upgrading. There was no clear documentation that this was
required and using it with 2.x.x yeilded some errors that eventually led me to
this realization. So lets make it easier for those after me who make the same
mistake by adding a nice sanity check and a note in the README.md file.