### PR TITLE
winston 3 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "optionalDependencies": {
     "unix-dgram": "^2.0.2"
   },
+  "peerDependencies": {
+    "winston": "^3.0.0"
+  },
   "devDependencies": {
     "eslint-config-populist": "^4.1.0",
     "vows": "^0.8.2",


### PR DESCRIPTION
Adding winston 3 to `peerDependencies` ensures that winston-syslog can only be used with winston3.

References:
- https://nodejs.org/en/blog/npm/peer-dependencies/
- Issue #95 
