### PR TITLE
Fixes winstonjs/winston-syslog#103

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -138,7 +138,7 @@ class Syslog extends Transport {
         //
         this.queue.push(syslogMsg);
 
-        return callback(err);
+        return callback();
       }
 
       //


### PR DESCRIPTION
I fixed the error thrown when logging before the TCP connection to the syslog server has been established. Please merge so we can use this module in our software.