### PR TITLE
Support protocol = 'udp' as an alias for 'udp4'

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -221,7 +221,8 @@ class Syslog extends Transport {
       this.socket = require('unix-dgram').createSocket('unix_dgram');
     } else {
       // UDP protocol
-      this.socket = new dgram.Socket(this.protocol);
+      const proto = this.protocol === 'udp' ? 'udp4' : this.protocol;
+      this.socket = new dgram.Socket(proto);
     }
 
     return callback(null);


### PR DESCRIPTION
`parseProtocol(protocol)` supports `protocol = 'udp'` as an alias for `protocol = 'udp4'`, but `'udp'` is not a valid argument for the `dgram.Socket` constructor. This patch makes `udp` a fully supported alias for `udp4`.

Note that recent Node.js documentation lists only a `dgram.createSocket(protocol)` factory method, perhaps moving forward we should use that factory rather than the `new dgram.Socket(protocol)` constructor.

References:
- https://nodejs.org/api/dgram.html#dgram_dgram_createsocket_options_callback