### PR TITLE
Call to this.socket.destroy crashes process

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -321,7 +321,7 @@ class Syslog extends Transport {
         this.socket.connect(this.port, this.host);
       }, interval * 1000);
     }).on('timeout', () => {
-      if (this.socket.readyState !== 'open') {
+      if (this.socket.readyState !== 'open' && this.socket.destroy) {
         this.socket.destroy();
       }
     });


### PR DESCRIPTION
- Regardless of the underlining socket implementation in use, this.socket.destroy is called on a timeout event.
- The dgram and unix-dgram modules do not include a socket.destroy method.
- Only the net module contains a socket.destroy method.