### PR TITLE
Handle oversize messages sent over UDP transports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
   - "11"

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -13,10 +13,7 @@ const glossy = require('glossy');
 const winston = require('winston');
 const Transport = require('winston-transport');
 const { MESSAGE, LEVEL } = require('triple-beam');
-
-// Maximum syslog message size for the UDP transport in bytes.
-// https://tools.ietf.org/html/rfc5426#section-3.2
-const MAX_UDP_LENGTH = 64000;
+const events = require('events');
 
 const _noop = () => {};
 
@@ -74,7 +71,7 @@ class Syslog extends Transport {
     //
     // Setup our Syslog and network members for later use.
     //
-    this.socket   = null;
+    this.socket = null;
     var Producer = options.customProducer || glossy.Produce;
     this.producer = new Producer({
       type: this.type,
@@ -82,6 +79,7 @@ class Syslog extends Transport {
       pid: this.pid,
       facility: this.facility
     });
+    this.emitter = new events.EventEmitter();
   }
 
   setOptions(options) {
@@ -96,7 +94,10 @@ class Syslog extends Transport {
     //
     // Merge the default message options.
     //
-    this.localhost = typeof options.localhost !== 'undefined' ? options.localhost : 'localhost';
+    this.localhost =
+      typeof options.localhost !== 'undefined'
+        ? options.localhost
+        : 'localhost';
     this.type = options.type || 'BSD';
     this.facility = options.facility || 'local0';
     this.pid = options.pid || process.pid;
@@ -106,9 +107,9 @@ class Syslog extends Transport {
   parseProtocol(protocol = this.protocol) {
     const parsedProtocol = utils.parseProtocol(protocol);
 
-    this.protocolType   = parsedProtocol.type;
+    this.protocolType = parsedProtocol.type;
     this.protocolFamily = parsedProtocol.family;
-    this.isDgram        = parsedProtocol.isDgram;
+    this.isDgram = parsedProtocol.isDgram;
 
     if (this.protocolType === 'unix' && !this.path) {
       throw new Error('`options.path` is required on unix dgram sockets.');
@@ -121,15 +122,38 @@ class Syslog extends Transport {
   // to write is larger than the maximum message size.
   //
   chunkMessage(buffer, callback = _noop) {
-    let offset = 0;
-    while (offset < buffer.length) {
-      this.inFlight++;
-      const length = offset + MAX_UDP_LENGTH > buffer.length ? buffer.length - offset : MAX_UDP_LENGTH;
-      this.socket.send(buffer, offset, length, this.port, this.host, callback);
-      offset += length;
-    }
-  }
+    this.socket.on('listening', () => {
+      // Get maximum syslog message size for the UDP transport in bytes.
+      // https://tools.ietf.org/html/rfc5426#section-3.2
+      const maxUdpLength = this.socket.getSendBufferSize();
+      let offset = 0;
+      const bufferToString = buffer.toString();
+      // console.log(bufferToString);
 
+      while (offset < buffer.length) {
+        this.inFlight++;
+        const length =
+          offset + maxUdpLength > buffer.length
+            ? buffer.length - offset
+            : maxUdpLength;
+        this.emitter.emit(
+          'chunk',
+          bufferToString.substring(offset, offset + length)
+        );
+        this.socket.send(
+          buffer,
+          offset,
+          length,
+          this.port,
+          this.host,
+          callback
+        );
+        offset += length;
+      }
+    });
+
+    this.socket.bind();
+  }
 
   //
   // ### function log (info, callback)
@@ -141,7 +165,9 @@ class Syslog extends Transport {
   log(info, callback) {
     let level = info[LEVEL];
     if (!~levels.indexOf(level)) {
-      return callback(new Error('Cannot log unknown syslog level: ' + info[LEVEL]));
+      return callback(
+        new Error('Cannot log unknown syslog level: ' + info[LEVEL])
+      );
     }
     level = level === 'warn' ? 'warning' : level;
     const output = info[MESSAGE];
@@ -156,7 +182,7 @@ class Syslog extends Transport {
     //
     // Attempt to connect to the socket
     //
-    this.connect((err) => {
+    this.connect(err => {
       if (err) {
         //
         // If there was an error enqueue the message
@@ -169,7 +195,7 @@ class Syslog extends Transport {
       //
       // On any error writing to the socket, enqueue the message
       //
-      const onError = (logErr) => {
+      const onError = logErr => {
         if (logErr) {
           this.queue.push(syslogMsg);
           this.emit('error', logErr);
@@ -183,7 +209,7 @@ class Syslog extends Transport {
       };
 
       const sendDgram = () => {
-        const buffer = new Buffer(syslogMsg);
+        const buffer = Buffer.from(syslogMsg);
 
         if (this.protocolType === 'udp') {
           this.chunkMessage(buffer, onError);
@@ -195,7 +221,7 @@ class Syslog extends Transport {
         } else {
           this.socket.once('congestion', onCongestion);
           this.inFlight++;
-          this.socket.send(buffer, (e) => {
+          this.socket.send(buffer, e => {
             this.socket.removeListener('congestion', onCongestion);
             onError(e);
           });
@@ -272,7 +298,9 @@ class Syslog extends Transport {
     // If the socket already exists then respond
     //
     if (this.socket) {
-      return ((!this.socket.readyState) || (this.socket.readyState === 'open')) || this.socket.connected
+      return !this.socket.readyState ||
+        this.socket.readyState === 'open' ||
+        this.socket.connected
         ? callback(null)
         : callback(true);
     }
@@ -314,8 +342,10 @@ class Syslog extends Transport {
     // On any error writing to the socket, emit the `logged` event
     // and the `error` event.
     //
-    const onError = (logErr) => {
-      if (logErr) { this.emit('error', logErr); }
+    const onError = logErr => {
+      if (logErr) {
+        this.emit('error', logErr);
+      }
       this.emit('logged');
       this.inFlight--;
     };
@@ -324,43 +354,47 @@ class Syslog extends Transport {
     // Listen to the appropriate events on the socket that
     // was just created.
     //
-    this.socket.on(readyEvent, () => {
-      //
-      // When the socket is ready, write the current queue
-      // to it.
-      //
-      this.socket.write(this.queue.join(''), 'utf8', onError);
+    this.socket
+      .on(readyEvent, () => {
+        //
+        // When the socket is ready, write the current queue
+        // to it.
+        //
+        this.socket.write(this.queue.join(''), 'utf8', onError);
 
-      this.emit('logged');
-      this.queue = [];
-      this.retries = 0;
-      this.connected = true;
-    }).on('error', function () {
-      //
-      // TODO: Pass this error back up
-      //
-    }).on('close', () => {
-      //
-      // Attempt to reconnect on lost connection(s), progressively
-      // increasing the amount of time between each try.
-      //
-      const interval = Math.pow(2, this.retries);
-      this.connected = false;
+        this.emit('logged');
+        this.queue = [];
+        this.retries = 0;
+        this.connected = true;
+      })
+      .on('error', function () {
+        //
+        // TODO: Pass this error back up
+        //
+      })
+      .on('close', () => {
+        //
+        // Attempt to reconnect on lost connection(s), progressively
+        // increasing the amount of time between each try.
+        //
+        const interval = Math.pow(2, this.retries);
+        this.connected = false;
 
-      setTimeout(() => {
-        this.retries++;
-        this.socket.connect(this.port, this.host);
-      }, interval * 1000);
-    }).on('timeout', () => {
-      if (this.socket.destroy) {
-        // https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback
-        this.socket.destroy();
-      } else if (this.socket.close) {
-        // https://nodejs.org/api/dgram.html#dgram_socket_close_callback
-        // https://www.npmjs.com/package/unix-dgram#socketclose
-        this.socket.close();
-      }
-    });
+        setTimeout(() => {
+          this.retries++;
+          this.socket.connect(this.port, this.host);
+        }, interval * 1000);
+      })
+      .on('timeout', () => {
+        if (this.socket.destroy) {
+          // https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback
+          this.socket.destroy();
+        } else if (this.socket.close) {
+          // https://nodejs.org/api/dgram.html#dgram_socket_close_callback
+          // https://www.npmjs.com/package/unix-dgram#socketclose
+          this.socket.close();
+        }
+      });
   }
 
   _unixDgramConnect(callback) {
@@ -368,8 +402,8 @@ class Syslog extends Transport {
 
     const flushQueue = () => {
       let sentMsgs = 0;
-      this.queue.forEach((msg) => {
-        const buffer = new Buffer(msg);
+      this.queue.forEach(msg => {
+        const buffer = Buffer.from(msg);
 
         if (!this.congested) {
           if (this.protocolType === 'udp') {
@@ -388,7 +422,7 @@ class Syslog extends Transport {
     };
 
     this.socket = require('unix-dgram').createSocket('unix_dgram');
-    this.socket.on('error', (err) => {
+    this.socket.on('error', err => {
       this.emit('error', err);
 
       if (err.syscall === 'connect') {

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -154,7 +154,7 @@ class Syslog extends Transport {
   // #### @callback {function} Continuation to respond to when complete.
   // Sends a single chunk from an oversize UDP buffer.
   //
-  _sendChunk(buffer, options, callback = _noop) {
+  _sendChunk(buffer, options, callback) {
     this.socket.send(
       buffer,
       options.offset,

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -14,6 +14,12 @@ const winston = require('winston');
 const Transport = require('winston-transport');
 const { MESSAGE, LEVEL } = require('triple-beam');
 
+// Maximum syslog message size for the UDP transport in bytes.
+// https://tools.ietf.org/html/rfc5426#section-3.2
+const MAX_UDP_LENGTH = 64000;
+
+const _noop = () => {};
+
 // Ensure we have the correct winston here.
 if (Number(winston.version.split('.')[0]) < 3) {
   throw new Error('Winston-syslog requires winston >= 3.0.0');
@@ -110,6 +116,22 @@ class Syslog extends Transport {
   }
 
   //
+  // Syslog messages sent over the UDP transport must be 64KB bytes or less. In
+  // order to avoid silent failures messages should be chunked when the buffer
+  // to write is larger than the maximum message size.
+  //
+  chunkMessage(buffer, callback = _noop) {
+    let offset = 0;
+    while (offset < buffer.length) {
+      this.inFlight++;
+      const length = offset + MAX_UDP_LENGTH > buffer.length ? buffer.length - offset : MAX_UDP_LENGTH;
+      this.socket.send(buffer, offset, length, this.port, this.host, callback);
+      offset += length;
+    }
+  }
+
+
+  //
   // ### function log (info, callback)
   // #### @info {object} All relevant log information
   // #### @callback {function} Continuation to respond to when complete.
@@ -164,8 +186,7 @@ class Syslog extends Transport {
         const buffer = new Buffer(syslogMsg);
 
         if (this.protocolType === 'udp') {
-          this.inFlight++;
-          this.socket.send(buffer, 0, buffer.length, this.port, this.host, onError);
+          this.chunkMessage(buffer, onError);
         } else if (this.protocol === 'unix') {
           this.inFlight++;
           this.socket.send(buffer, 0, buffer.length, this.path, onError);
@@ -351,9 +372,15 @@ class Syslog extends Transport {
         const buffer = new Buffer(msg);
 
         if (!this.congested) {
-          this.socket.send(buffer, function () {
-            ++sentMsgs;
-          });
+          if (this.protocolType === 'udp') {
+            this.chunkMessage(buffer, () => {
+              ++sentMsgs;
+            });
+          } else {
+            this.socket.send(buffer, function () {
+              ++sentMsgs;
+            });
+          }
         }
       });
 

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -123,7 +123,9 @@ class Syslog extends Transport {
   // to write is larger than the maximum message size.
   //
   chunkMessage(buffer, callback = _noop) {
-    const _chunkMessage = () => {
+    if (!this.connected) {
+      this.queue.push(buffer);
+    } else {
       // Get maximum syslog message size for the UDP transport in bytes.
       // https://tools.ietf.org/html/rfc5426#section-3.2
       const maxUdpLength = this.socket.getSendBufferSize();
@@ -142,12 +144,6 @@ class Syslog extends Transport {
         );
         offset += length;
       }
-    };
-
-    if (!this.connected) {
-      this.socket.once('listening', _chunkMessage);
-    } else {
-      _chunkMessage();
     }
   }
 
@@ -299,6 +295,11 @@ class Syslog extends Transport {
       })
         .on('listening', () => {
           this.connected = true;
+          let msg = this.queue.shift();
+          while (msg) {
+            this.chunkMessage(msg);
+            msg = this.queue.shift();
+          }
         });
       this.socket.bind();
     }

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -123,7 +123,7 @@ class Syslog extends Transport {
   // to write is larger than the maximum message size.
   //
   chunkMessage(buffer, callback = _noop) {
-    this.socket.on('listening', () => {
+    const _chunkMessage = () => {
       // Get maximum syslog message size for the UDP transport in bytes.
       // https://tools.ietf.org/html/rfc5426#section-3.2
       const maxUdpLength = this.socket.getSendBufferSize();
@@ -142,9 +142,13 @@ class Syslog extends Transport {
         );
         offset += length;
       }
-    });
+    };
 
-    this.socket.bind();
+    if (!this.connected) {
+      this.socket.once('listening', _chunkMessage);
+    } else {
+      _chunkMessage();
+    }
   }
 
   //
@@ -292,7 +296,11 @@ class Syslog extends Transport {
       // https://nodejs.org/api/all.html#dgram_class_dgram_socket
       this.socket = dgram.createSocket({
         type: proto
-      });
+      })
+        .on('listening', () => {
+          this.connected = true;
+        });
+      this.socket.bind();
     }
 
     return callback(null);

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -13,7 +13,6 @@ const glossy = require('glossy');
 const winston = require('winston');
 const Transport = require('winston-transport');
 const { MESSAGE, LEVEL } = require('triple-beam');
-const events = require('events');
 
 const _noop = () => {};
 
@@ -79,7 +78,6 @@ class Syslog extends Transport {
       pid: this.pid,
       facility: this.facility
     });
-    this.emitter = new events.EventEmitter();
   }
 
   setOptions(options) {
@@ -117,6 +115,9 @@ class Syslog extends Transport {
   }
 
   //
+  // ### function chunkMessage (buffer, callback)
+  // #### @buffer {Buffer} Syslog message buffer.
+  // #### @callback {function} Continuation to respond to when complete.
   // Syslog messages sent over the UDP transport must be 64KB bytes or less. In
   // order to avoid silent failures messages should be chunked when the buffer
   // to write is larger than the maximum message size.
@@ -127,8 +128,6 @@ class Syslog extends Transport {
       // https://tools.ietf.org/html/rfc5426#section-3.2
       const maxUdpLength = this.socket.getSendBufferSize();
       let offset = 0;
-      const bufferToString = buffer.toString();
-      // console.log(bufferToString);
 
       while (offset < buffer.length) {
         this.inFlight++;
@@ -136,16 +135,9 @@ class Syslog extends Transport {
           offset + maxUdpLength > buffer.length
             ? buffer.length - offset
             : maxUdpLength;
-        this.emitter.emit(
-          'chunk',
-          bufferToString.substring(offset, offset + length)
-        );
-        this.socket.send(
+        this._sendChunk(
           buffer,
-          offset,
-          length,
-          this.port,
-          this.host,
+          { offset: offset, length: length, port: this.port, host: this.host },
           callback
         );
         offset += length;
@@ -153,6 +145,24 @@ class Syslog extends Transport {
     });
 
     this.socket.bind();
+  }
+
+  //
+  // ### function _sendChunk (buffer, options, callback)
+  // #### @buffer {Buffer} Syslog message buffer.
+  // #### @options {object} Options for the message send method.
+  // #### @callback {function} Continuation to respond to when complete.
+  // Sends a single chunk from an oversize UDP buffer.
+  //
+  _sendChunk(buffer, options, callback = _noop) {
+    this.socket.send(
+      buffer,
+      options.offset,
+      options.length,
+      options.port,
+      options.host,
+      callback
+    );
   }
 
   //

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -286,7 +286,7 @@ class Syslog extends Transport {
       return this._unixDgramConnect(callback);
     } else if (this.protocol === 'unix') {
       this.socket = require('unix-dgram').createSocket('unix_dgram');
-    } else {
+    } else if (!this.socket) {
       // UDP protocol
       const proto = this.protocol === 'udp' ? 'udp4' : this.protocol;
       // https://nodejs.org/api/all.html#dgram_class_dgram_socket

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,42 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -71,6 +107,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "async": {
       "version": "2.6.2",
@@ -954,6 +996,12 @@
       "integrity": "sha512-VC0CjnWJylKB1iov4u76/W/5Ef0ydDkjtYWxoZ9t3HdWlSnZQwZL5MgFikaB/EtQ4RmMEw3tmQzuYnZA2/Ja1g==",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kuler": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
@@ -1022,6 +1070,12 @@
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1095,6 +1149,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -1252,6 +1319,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -1488,6 +1572,38 @@
         }
       }
     },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
@@ -1656,6 +1772,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "vows test/*-test.js --spec"
   },
   "engines": {
-    "node": ">= 4.2.2"
+    "node": ">= 8"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "eslint-config-populist": "4.2.0",
+    "sinon": "^7.5.0",
     "vows": "^0.8.2",
     "winston": "^3.0.0"
   },

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -12,38 +12,20 @@ let transport;
 
 const { MESSAGE, LEVEL } = require('triple-beam');
 
-vows.describe('syslog messages').addBatch({
-  'opening fake syslog server': {
-    'topic': function () {
-      const self = this;
-      server = dgram.createSocket('udp4');
-      server.on('listening', function () {
-        self.callback();
-      });
-
-      server.bind(PORT);
-    },
-    'default format': {
+vows
+  .describe('syslog messages')
+  .addBatch({
+    'opening fake syslog server': {
       'topic': function () {
         const self = this;
-        server.once('message', function (msg) {
-          parser.parse(msg, function (d) {
-            self.callback(null, d);
-          });
+        server = dgram.createSocket('udp4');
+        server.on('listening', function () {
+          self.callback();
         });
 
-        transport = new Syslog({
-          port: PORT
-        });
-        transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping' }, function (err) {
-          assert.ifError(err);
-        });
+        server.bind(PORT);
       },
-      'should have host field set to localhost': function (msg) {
-        assert.equal(msg.host, 'localhost');
-        transport.close();
-      },
-      'setting locahost option to a different falsy value (null)': {
+      'default format': {
         'topic': function () {
           const self = this;
           server.once('message', function (msg) {
@@ -53,19 +35,17 @@ vows.describe('syslog messages').addBatch({
           });
 
           transport = new Syslog({
-            port: PORT,
-            localhost: null
+            port: PORT
           });
-
-          transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping2' }, function (err) {
+          transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping' }, function (err) {
             assert.ifError(err);
           });
         },
-        'should have host different from localhost': function (msg) {
-          assert.notEqual(msg.host, 'localhost');
+        'should have host field set to localhost': function (msg) {
+          assert.equal(msg.host, 'localhost');
           transport.close();
         },
-        'setting appName option to hello': {
+        'setting locahost option to a different falsy value (null)': {
           'topic': function () {
             const self = this;
             server.once('message', function (msg) {
@@ -76,19 +56,20 @@ vows.describe('syslog messages').addBatch({
 
             transport = new Syslog({
               port: PORT,
-              type: '5424',
-              appName: 'hello'
+              localhost: null
             });
 
-            transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'app name test' }, function (err) {
+            transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping2' }, function (
+              err
+            ) {
               assert.ifError(err);
             });
           },
-          'should have appName field set to hello': function (msg) {
-            assert.equal(msg.appName, 'hello');
+          'should have host different from localhost': function (msg) {
+            assert.notEqual(msg.host, 'localhost');
             transport.close();
           },
-          'setting app_name option to hello': {
+          'setting appName option to hello': {
             'topic': function () {
               const self = this;
               server.once('message', function (msg) {
@@ -100,64 +81,95 @@ vows.describe('syslog messages').addBatch({
               transport = new Syslog({
                 port: PORT,
                 type: '5424',
-                app_name: 'hello'
+                appName: 'hello'
               });
 
-              transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'app name test' }, function (err) {
-                assert.ifError(err);
-              });
+              transport.log(
+                { [LEVEL]: 'debug', [MESSAGE]: 'app name test' },
+                function (err) {
+                  assert.ifError(err);
+                }
+              );
             },
             'should have appName field set to hello': function (msg) {
               assert.equal(msg.appName, 'hello');
               transport.close();
+            },
+            'setting app_name option to hello': {
+              'topic': function () {
+                const self = this;
+                server.once('message', function (msg) {
+                  parser.parse(msg, function (d) {
+                    self.callback(null, d);
+                  });
+                });
+
+                transport = new Syslog({
+                  port: PORT,
+                  type: '5424',
+                  app_name: 'hello'
+                });
+
+                transport.log(
+                  { [LEVEL]: 'debug', [MESSAGE]: 'app name test' },
+                  function (err) {
+                    assert.ifError(err);
+                  }
+                );
+              },
+              'should have appName field set to hello': function (msg) {
+                assert.equal(msg.appName, 'hello');
+                transport.close();
+              }
             }
           }
         }
+      },
+      'teardown': function () {
+        server.close();
       }
-    },
-    'teardown': function () {
-      server.close();
     }
-  }
-}).addBatch({
-  'opening fake syslog server': {
-    'topic': function () {
-      var self = this;
-      server = dgram.createSocket('udp4');
-      server.on('listening', function () {
-        self.callback();
-      });
-
-      server.bind(PORT);
-    },
-    'Custom producer': {
+  })
+  .addBatch({
+    'opening fake syslog server': {
       'topic': function () {
         var self = this;
-        server.once('message', function (msg) {
-          self.callback(null, msg.toString());
+        server = dgram.createSocket('udp4');
+        server.on('listening', function () {
+          self.callback();
         });
 
-        function CustomProducer() {}
-        CustomProducer.prototype.produce = function (opts) {
-          return 'test ' + opts.severity + ': ' + opts.message;
-        };
-
-        transport = new Syslog({
-          port: PORT,
-          customProducer: CustomProducer
-        });
-
-        transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping' }, function (err) {
-          assert.ifError(err);
-        });
+        server.bind(PORT);
       },
-      'should apply custom syslog format': function (msg) {
-        assert.equal(msg, 'test debug: ping');
-        transport.close();
+      'Custom producer': {
+        'topic': function () {
+          var self = this;
+          server.once('message', function (msg) {
+            self.callback(null, msg.toString());
+          });
+
+          function CustomProducer() {}
+          CustomProducer.prototype.produce = function (opts) {
+            return 'test ' + opts.severity + ': ' + opts.message;
+          };
+
+          transport = new Syslog({
+            port: PORT,
+            customProducer: CustomProducer
+          });
+
+          transport.log({ [LEVEL]: 'debug', [MESSAGE]: 'ping' }, function (err) {
+            assert.ifError(err);
+          });
+        },
+        'should apply custom syslog format': function (msg) {
+          assert.equal(msg, 'test debug: ping');
+          transport.close();
+        }
+      },
+      'teardown': function () {
+        server.close();
       }
-    },
-    'teardown': function () {
-      server.close();
     }
-  }
-}).export(module);
+  })
+  .export(module);

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const vows = require('vows');
+const assert = require('assert');
+const Syslog = require('../lib/winston-syslog.js').Syslog;
+const dgram = require('dgram');
+
+const PORT = 11229;
+let server;
+let transport;
+let maxUdpLength;
+let message;
+
+const { MESSAGE, LEVEL } = require('triple-beam');
+
+vows
+  .describe('syslog message')
+  .addBatch({
+    'Opening fake syslog UDP server': {
+      'topic': function () {
+        const self = this;
+        server = dgram.createSocket('udp4');
+        server.on('listening', function () {
+          // Get the maximum buffer size for the current server.
+          maxUdpLength = server.getSendBufferSize();
+          self.callback();
+        });
+
+        server.bind(PORT);
+      },
+      'logging an oversize message': {
+        'topic': function () {
+          const chunks = [];
+          // Generate message larger than max UDP message size.
+          message = '#'.repeat(65000);
+          transport = new Syslog({
+            port: PORT
+          });
+
+          transport.emitter.on('chunk', function (chunk) {
+            chunks.push(chunk);
+          });
+
+          transport.log({ [LEVEL]: 'debug', [MESSAGE]: message }, function (
+            err
+          ) {
+            assert.ifError(err);
+          });
+
+          return chunks;
+        },
+        'correct number of chunks sent': function (chunks) {
+          const sentMessage = chunks.reduce((acc, chunk) => {
+            return (acc += chunk);
+          }, '');
+          assert.equal(
+            Math.ceil(sentMessage.length / maxUdpLength),
+            chunks.length
+          );
+        },
+        'full message sent': function (chunks) {
+          const sentMessageBody = chunks.reduce((acc, chunk) => {
+            const regex = /#+/gm;
+            const msg = chunk.match(regex);
+            return (acc += msg);
+          }, '');
+
+          assert.equal(sentMessageBody, message);
+          transport.close();
+        }
+      },
+      'teardown': function () {
+        server.close();
+      }
+    }
+  })
+  .export(module);

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -53,7 +53,8 @@ vows
         'correct number of chunks sent': function () {
           assert(transport.chunkMessage.calledOnce);
 
-          sentMessage = transport.chunkMessage.getCall(0).args[0].toString();
+          sentMessage = transport.chunkMessage.getCall(0).args[0];
+          console.log(sentMessage);
           numChunks = Math.ceil(sentMessage.length / maxUdpLength);
           assert.equal(numChunks, transport._sendChunk.callCount);
         },

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -51,7 +51,7 @@ vows
           return null;
         },
         'correct number of chunks sent': function () {
-          assert(transport.chunkMessage.calledOnce);
+          assert(transport.chunkMessage.calledTwice);
 
           sentMessage = transport.chunkMessage.getCall(0).args[0];
           numChunks = Math.ceil(sentMessage.length / maxUdpLength);
@@ -61,6 +61,7 @@ vows
           let offset = 0;
           let i = 0;
 
+          sentMessage = transport.chunkMessage.getCall(0).args[0];
           while (offset < sentMessage.length) {
             const length =
               offset + maxUdpLength > sentMessage.length

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -54,7 +54,6 @@ vows
           assert(transport.chunkMessage.calledOnce);
 
           sentMessage = transport.chunkMessage.getCall(0).args[0];
-          console.log(sentMessage);
           numChunks = Math.ceil(sentMessage.length / maxUdpLength);
           assert.equal(numChunks, transport._sendChunk.callCount);
         },


### PR DESCRIPTION
Attempting to send large messages over UDP causes silent failures if the message length is larger than the max allowed by UDP for the given environment. This checks the size of the buffer vs the limit and sends messages in chunks if required.