### PR TITLE
Set maximum UDP payload to 65507 bytes

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -128,17 +128,22 @@ class Syslog extends Transport {
     if (!this.connected) {
       this.queue.push(buffer);
     } else {
-      // Get maximum syslog message size for the UDP transport in bytes.
+      // Maximum payload for the UDP transport
+      // 65535 − 8 bytes UDP header − 20 bytes IP header
       // https://tools.ietf.org/html/rfc5426#section-3.2
-      const maxUdpLength = this.socket.getSendBufferSize();
+      // This makes sense on loopback interfaces with MTU = 65536
+      // For non-loopback messages, it's impossible to know in advance
+      // the MTU of each interface through which a packet might be routed
+      // https://nodejs.org/api/dgram.html
+      const MAX_UDP_PAYLOAD = 65507;
       let offset = 0;
 
       while (offset < buffer.length) {
         this.inFlight++;
         const length =
-          offset + maxUdpLength > buffer.length
+          offset + MAX_UDP_PAYLOAD > buffer.length
             ? buffer.length - offset
-            : maxUdpLength;
+            : MAX_UDP_PAYLOAD;
         this._sendChunk(
           buffer,
           { offset: offset, length: length, port: this.port, host: this.host },


### PR DESCRIPTION
Original implementation of UDP chunking assumes `maxUdpLength = server.getSendBufferSize();`. However, `getSendBufferSize()` returns the total size of the send _buffer_ (`SO_SNDBUF`), not the maximum size of payload in an individual UDP _packet_. From `socket(7)` on Linux:

```
       SO_SNDBUF
              Sets or gets the maximum socket send buffer in bytes.  The
              kernel doubles this value (to allow space for bookkeeping
              overhead) when it is set using setsockopt(2), and this doubled
              value is returned by getsockopt(2).  The default value is set
              by the /proc/sys/net/core/wmem_default file and the maximum
              allowed value is set by the /proc/sys/net/core/wmem_max file.
              The minimum (doubled) value for this option is 2048.
```

On Linux machines I tested this on, this value (`proc/sys/net/core/wmem_default`) is 212992 bytes. We were getting `EMSGSIZE` errors from the Linux kernel on oversized messages when using such 212992 byte chunks.

This PR fixes the maximum UDP payload size to the theoretical maximum. Per RFC 5426 and Node.js documentation, this is:

65535 − 8 bytes UDP header − 20 bytes IP header = 65507

assuming the loopback interface with a MTU of 64 kb. If the packet is routed to other interfaces / through other hosts, there are no guarantees that its length will not exceed some interface MTU and be dropped.

References:

https://tools.ietf.org/html/rfc5426#section-3.2
https://nodejs.org/api/dgram.html
https://en.wikipedia.org/wiki/User_Datagram_Protocol#UDP_datagram_structure
