### PR TITLE
Remove unused dependency "cycle"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -367,11 +367,6 @@
         "which": "^1.2.9"
       }
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "syslog"
   ],
   "dependencies": {
-    "cycle": "^1.0.3",
     "eslint-config-populist": "^4.2.0",
     "glossy": "^0.1.7",
     "sinon": "^8.0.2",


### PR DESCRIPTION
"cycle" is unused and appears to be unmaintained with no updates the
last six years. It does not have a license specified in package.json
so projects that use license checkers have a problem using
winston-syslog due to the presence of cycle.

The "cycle" module has ignored issues and pull requests to address the
missing license issue.

* https://github.com/dscape/cycle/issues/21
* https://github.com/dscape/cycle/pull/26