### PR TITLE
Catch exceptions throwdn by socket send

### DIFF
--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -163,14 +163,18 @@ class Syslog extends Transport {
   // Sends a single chunk from an oversize UDP buffer.
   //
   _sendChunk(buffer, options, callback) {
-    this.socket.send(
-      buffer,
-      options.offset,
-      options.length,
-      options.port,
-      options.host,
-      callback
-    );
+    try {
+      this.socket.send(
+        buffer,
+        options.offset,
+        options.length,
+        options.port,
+        options.host,
+        callback
+      );
+    } catch (err) {
+      callback(err);
+    }
   }
 
   //


### PR DESCRIPTION
We experience sometimes issues where udp socket send throws an exception, see https://sentry.iobroker.net/share/issue/0fe0c0c9a1f94a12a06676ee2195f5ef/

This PR catches this and calls callback with the error, fixes #161 