### PR TITLE
Add TLSsocket Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 
 * __secureProtocol:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
 * __ciphers:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
-* __ecdhCurve:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket \
+* __ecdhCurve:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
 
 *Metadata:* Logged as string compiled by [glossy][3].
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 * __app_name:__ The name of the application (Default: `process.title`).
 * __eol:__ The end of line character to be added to the end of the message 
 (Default: Message without modifications).
-
 * __checkServerIdentity:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
-
 * __secureProtocol:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
 * __ciphers:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
 * __ecdhCurve:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket

--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ In addition to the options accepted by the syslog (compliant with [RFC 3164][1] 
 * __localhost:__ Host to indicate that log messages are coming from (Default: `localhost`).
 * __type:__ The type of the syslog protocol to use (Default: `BSD`, also valid: `'3164'`, `'5424'`, `'RFC3164'` or `'RFC5424'`).
 * __app_name:__ The name of the application (Default: `process.title`).
-* __eol:__ The end of line character to be added to the end of the message (Default: Message without modifications).
+* __eol:__ The end of line character to be added to the end of the message 
+(Default: Message without modifications).
+
+* __checkServerIdentity:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
+
+* __secureProtocol:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
+* __ciphers:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket
+* __ecdhCurve:__ check TLSScoket options https://nodejs.org/api/tls.html#class-tlstlssocket \
 
 *Metadata:* Logged as string compiled by [glossy][3].
 

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -81,7 +81,6 @@ class Syslog extends Transport {
       facility: this.facility
     });
   }
-
   setOptions(options) {
     this.host = options.host || 'localhost';
     this.port = options.port || 514;
@@ -91,6 +90,24 @@ class Syslog extends Transport {
     this.endOfLine = options.eol;
 
     this.parseProtocol(this.protocol);
+    // this options provides a secure socket for sending logs to the syslog server based on
+    // TLSSocket options (https://nodejs.org/api/tls.html#class-tlstlssocket). 
+    //Therefore, TLSSocket options are configurable through the code.
+    // Also, to secure the connection, default values of TLS options are set,
+    // which are based on the Protection Profile for Application Software 
+    //(https://www.niap-ccevs.org/MMO/PP/-394-/pp_app_v1.2.htm).
+
+    this.checkServerIdentity = options.checkServerIdentity || undefined, // check FQDN
+    this.secureProtocol = options.secureProtocol || 'TLSv1_2_method',
+    this.ciphers = options.ciphers  || 'ECDHE-ECDSA-AES256-GCM-SHA384:\
+    ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:\
+    ECDHE-ECDSA-AES128-GCM-SHA256:\
+    ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:\
+    ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:\
+    DHE-RSA-AES256-SHA256:ECDHE-ECDSA-AES128-SHA256:\
+    ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256',
+    this.ecdhCurve = options.ecdhCurve || 'secp384r1'
+    // end options for secure socket 
 
     //
     // Merge the default message options.
@@ -342,9 +359,17 @@ class Syslog extends Transport {
     if (this.isDgram) {
       return this.connectDgram(callback);
     }
-
+    // Set Secure options for TLS
+    const options = {
+      servername: this.host,
+      checkServerIdentity: () => this.checkServerIdentity, // check FQDN
+      secureProtocol: this.secureProtocol,
+      ciphers: this.ciphers,
+      ecdhCurve: this.ecdhCurve
+    };
+    
     this.socket = /^tls[4|6]?$/.test(this.protocol)
-      ? new secNet.TLSSocket()
+      ? new secNet.TLSSocket(this.socket, options) // Set options for TLSSocket
       : new net.Socket();
     this.socket.setKeepAlive(true);
     this.socket.setNoDelay();

--- a/lib/winston-syslog.js
+++ b/lib/winston-syslog.js
@@ -81,6 +81,7 @@ class Syslog extends Transport {
       facility: this.facility
     });
   }
+  
   setOptions(options) {
     this.host = options.host || 'localhost';
     this.port = options.port || 514;


### PR DESCRIPTION
This repository helps to provide a secure socket for sending logs to the syslog server based on TLSSocket options (https://nodejs.org/api/tls.html#class-tlstlssocket). Therefore, TLSSocket options are configurable through the code. Also, to secure the connection, default values of TLS options are set, which are based on the Protection Profile for Application Software (https://www.niap-ccevs.org/MMO/PP/-394-/pp_app_v1.2.htm).