### PR TITLE
Fix missing declaration of direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "syslog"
   ],
   "dependencies": {
-    "glossy": "^0.1.7"
+    "glossy": "^0.1.7",
+    "triple-beam": "^1.3.0",
+    "winston-transport": "^4.5.0"
   },
   "optionalDependencies": {
     "unix-dgram": "2.0.6"


### PR DESCRIPTION
`triple-beam` and `winston-transport` are directly required by the code but they are missing in `package.json` file. It may work in environments where hoisting of `node_modules` is allowed but using PNPM in strict mode (especially with prod dependencies only) causes fatal errors on not found modules.